### PR TITLE
[FEAT] 공통 응답 및 에러처리를 구현하였습니다. (#1)

### DIFF
--- a/src/main/java/com/brainpix/api/ApiResponse.java
+++ b/src/main/java/com/brainpix/api/ApiResponse.java
@@ -1,0 +1,48 @@
+package com.brainpix.api;
+
+import com.brainpix.api.code.error.ErrorCode;
+import com.brainpix.api.code.success.CommonSuccessCode;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"success", "code", "message", "data"})
+public class ApiResponse<T> {
+
+	private final boolean success;
+	private final String code;
+	private final String message;
+	private final T data;
+
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, CommonSuccessCode.SUCCESS.getCode(),
+			CommonSuccessCode.SUCCESS.getMessage(), data);
+	}
+
+	public static ApiResponse<Void> successWithNoData() {
+		return new ApiResponse<>(true, CommonSuccessCode.SUCCESS.getCode(),
+			CommonSuccessCode.SUCCESS.getMessage(), null);
+	}
+
+	public static <T> ApiResponse<T> created(T data) {
+		return new ApiResponse<>(true, CommonSuccessCode.CREATED.getCode(),
+			CommonSuccessCode.CREATED.getMessage(), data);
+	}
+
+	public static ApiResponse<Void> createdWithNoData() {
+		return new ApiResponse<>(true, CommonSuccessCode.CREATED.getCode(),
+			CommonSuccessCode.CREATED.getMessage(), null);
+	}
+
+	public static ApiResponse<?> createFail(ErrorCode errorCode) {
+		return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+	}
+
+	public static ApiResponse<?> createFail(ErrorCode errorCode, String message) {
+		return new ApiResponse<>(false, errorCode.getCode(), message, null);
+	}
+}

--- a/src/main/java/com/brainpix/api/code/error/CommonErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/CommonErrorCode.java
@@ -1,0 +1,23 @@
+package com.brainpix.api.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+	// COMMON 4XX
+	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON400", "파라미터가 올바르지 않습니다."),
+	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "찾을 수 없는 리소스입니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "허용되지 않는 HTTP Method입니다."),
+
+	// COMMON 5XX
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/brainpix/api/code/error/ErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.brainpix.api.code.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+	HttpStatus getHttpStatus();
+
+	String getCode();
+
+	String getMessage();
+}

--- a/src/main/java/com/brainpix/api/code/success/CommonSuccessCode.java
+++ b/src/main/java/com/brainpix/api/code/success/CommonSuccessCode.java
@@ -1,0 +1,20 @@
+package com.brainpix.api.code.success;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonSuccessCode implements SuccessCode {
+
+	SUCCESS(HttpStatus.OK, "COMMON200", "요청이 성공적으로 처리되었습니다."),
+	CREATED(HttpStatus.CREATED, "COMMON201", "리소스가 성공적으로 생성되었습니다.");
+
+	private final HttpStatus httpStatus;
+
+	private final String code;
+
+	private final String message;
+}

--- a/src/main/java/com/brainpix/api/code/success/SuccessCode.java
+++ b/src/main/java/com/brainpix/api/code/success/SuccessCode.java
@@ -1,0 +1,12 @@
+package com.brainpix.api.code.success;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+
+	HttpStatus getHttpStatus();
+
+	String getCode();
+
+	String getMessage();
+}

--- a/src/main/java/com/brainpix/api/exception/BrainPixException.java
+++ b/src/main/java/com/brainpix/api/exception/BrainPixException.java
@@ -1,0 +1,13 @@
+package com.brainpix.api.exception;
+
+import com.brainpix.api.code.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BrainPixException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/com/brainpix/api/handler/ExceptionAdvice.java
+++ b/src/main/java/com/brainpix/api/handler/ExceptionAdvice.java
@@ -1,0 +1,76 @@
+package com.brainpix.api.handler;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.brainpix.api.ApiResponse;
+import com.brainpix.api.code.error.CommonErrorCode;
+import com.brainpix.api.code.error.ErrorCode;
+import com.brainpix.api.exception.BrainPixException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * ExceptionAdvice
+ * 모든 예외 처리가 구현되지 않았습니다
+ * 테스트하시다가 공통 api 응답 처리가 되지 않으면 추가 부탁드립니다
+ */
+@Slf4j
+@RestControllerAdvice
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+	@ExceptionHandler(BrainPixException.class)
+	public ResponseEntity<Object> handleRestApiException(BrainPixException ex) {
+		ErrorCode errorCode = ex.getErrorCode();
+		return handleExceptionInternal(errorCode);
+	}
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException ex) {
+		log.warn("handleIllegalArgument");
+		ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+		return handleExceptionInternal(errorCode, ex.getMessage());
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
+		HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+		log.warn("handleHttpRequestMethodNotSupportedException");
+		ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+		return handleExceptionInternal(errorCode);
+	}
+
+	@Override
+	public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers,
+		HttpStatusCode status, WebRequest request) {
+
+		log.warn("MethodArgumentNotValidException ");
+		ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+		return handleExceptionInternal(errorCode, getDefaultMessage(e));
+	}
+
+	private static String getDefaultMessage(MethodArgumentNotValidException e) {
+		StringBuilder message = new StringBuilder();
+		for (ObjectError error : e.getBindingResult().getAllErrors()) {
+			message.append(error.getDefaultMessage()).append("\u00a0");
+		}
+		return message.toString();
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode) {
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.createFail(errorCode));
+	}
+
+	private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode, final String message) {
+		return ResponseEntity.status(errorCode.getHttpStatus()).body(ApiResponse.createFail(errorCode, message));
+	}
+}
+


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #1

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
### 사용법
#### 실패시
각 도메인별 ErrorCode를 작성하신 후 필요시 BrainPixException에 해당 ErrorCode를 넣고 throw하시면 됩니다
#### 성공시
```
// 200 응답
ResponseEntity.ok(ApiResponse.success(data));
// 그 외의 HTTP 응답 코드(201)
new ResponseEntity<>(ApiResponse.created(message), HttpStatus.CREATED);
```
### ExceptionAdvice
ExceptionAdvice는 모든 Exception에 대한 처리를 하지 않았으므로 ResponseEntityExceptionHandler에서 해당 예외 처리를 오버라이드 하시거나 ResponseEntityExceptionHandler에 정의되지 않은 Exception은 `@ExceptionHandler`로 정의해 주시면 됩니다
기본적인 Exception에 대한 예외처리는 추후 추가하도록 하겠습니다