### PR TITLE
[FEAT] 알림 관련 기능 프로토타입 구현 #7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/brainpix/alarm/controller/AlarmController.java
+++ b/src/main/java/com/brainpix/alarm/controller/AlarmController.java
@@ -1,0 +1,76 @@
+package com.brainpix.alarm.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.brainpix.alarm.dto.CreateAlarmDto;
+import com.brainpix.alarm.dto.GetAlarmDto;
+import com.brainpix.alarm.dto.GetUnreadAlarmDto;
+import com.brainpix.alarm.service.AlarmService;
+import com.brainpix.api.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/alarm")
+public class AlarmController {
+
+	private final AlarmService alarmService;
+
+	// 알림 생성 API
+	@PostMapping
+	public ResponseEntity<?> createAlarm(@RequestBody CreateAlarmDto.Request request) {
+
+		CreateAlarmDto.Response data = alarmService.createAlarm(request);
+
+		return new ResponseEntity<>(ApiResponse.success(data), HttpStatus.CREATED);
+	}
+
+	// 알림 읽음 처리 API
+	@PatchMapping("/read/{alarmId}")
+	public ResponseEntity<?> readAlarm(@PathVariable String alarmId) {
+
+		alarmService.readAlarm(alarmId);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	// 일반 알림 조회 API
+	// 시큐리티 적용 전까지 임시로 userId를 RequestParam 으로 받아서 사용
+	@GetMapping
+	public ResponseEntity<?> getAlarmList(Pageable pageable, @RequestParam Long userId) {
+
+		GetAlarmDto.Response data = alarmService.getAlarm(pageable, userId);
+
+		return ResponseEntity.ok(ApiResponse.success(data));
+	}
+
+	// 휴지통 알림 조회 API
+	// 시큐리티 적용 전까지 임시로 userId를 RequestParam 으로 받아서 사용
+	@GetMapping("/trash")
+	public ResponseEntity<?> getTrashAlarmList(Pageable pageable, @RequestPart Long userId) {
+
+		GetAlarmDto.Response data = alarmService.getTrashAlarm(pageable, userId);
+
+		return ResponseEntity.ok(ApiResponse.success(data));
+	}
+
+	@GetMapping("/count")
+	public ResponseEntity<?> getUnreadAlarmCount(@RequestParam Long userId) {
+
+		GetUnreadAlarmDto.Response data = alarmService.getUnreadAlarmCount(userId);
+
+		return ResponseEntity.ok(ApiResponse.success(data));
+	}
+}

--- a/src/main/java/com/brainpix/alarm/controller/AlarmController.java
+++ b/src/main/java/com/brainpix/alarm/controller/AlarmController.java
@@ -3,6 +3,7 @@ package com.brainpix.alarm.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,9 +40,9 @@ public class AlarmController {
 
 	// 알림 읽음 처리 API
 	@PatchMapping("/read/{alarmId}")
-	public ResponseEntity<?> readAlarm(@PathVariable String alarmId) {
+	public ResponseEntity<?> readAlarm(@PathVariable String alarmId, @RequestParam Long userId) {
 
-		alarmService.readAlarm(alarmId);
+		alarmService.readAlarm(alarmId, userId);
 
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
@@ -66,6 +67,7 @@ public class AlarmController {
 		return ResponseEntity.ok(ApiResponse.success(data));
 	}
 
+	// 알림 수 조회 API
 	@GetMapping("/count")
 	public ResponseEntity<?> getUnreadAlarmCount(@RequestParam Long userId) {
 
@@ -73,4 +75,41 @@ public class AlarmController {
 
 		return ResponseEntity.ok(ApiResponse.success(data));
 	}
+
+	// 알림 휴지통으로 보내기 API
+	@PatchMapping("/trash/{alarmId}")
+	public ResponseEntity<?> addTrashAlarm(@PathVariable String alarmId, @RequestParam Long userId) {
+
+		alarmService.addTrashAlarm(alarmId, userId);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	// 알림 휴지통에서 복구 API
+	@PatchMapping("/restore/{alarmId}")
+	public ResponseEntity<?> restoreAlarm(@PathVariable String alarmId, @RequestParam Long userId) {
+
+		alarmService.restoreAlarm(alarmId, userId);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	// 알림 삭제 API
+	@DeleteMapping("/delete/{alarmId}")
+	public ResponseEntity<?> deleteAlarm(@PathVariable String alarmId, @RequestParam Long userId) {
+
+		alarmService.deleteOneAlarm(alarmId, userId);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	// 알림 전체 삭제 API
+	@DeleteMapping("/delete")
+	public ResponseEntity<?> deleteAllAlarm(@RequestParam Long userId) {
+
+		alarmService.deleteAllAlarm(userId);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
 }

--- a/src/main/java/com/brainpix/alarm/converter/CreateAlarmConverter.java
+++ b/src/main/java/com/brainpix/alarm/converter/CreateAlarmConverter.java
@@ -1,0 +1,28 @@
+package com.brainpix.alarm.converter;
+
+import java.util.Map;
+
+import com.brainpix.alarm.dto.CreateAlarmDto;
+import com.brainpix.alarm.model.Alarm;
+import com.brainpix.alarm.model.AlarmInfo;
+import com.brainpix.alarm.template.AlarmTemplate;
+import com.brainpix.alarm.utils.AlarmInfoParser;
+
+public class CreateAlarmConverter {
+
+	public static Alarm convertToAlarm(CreateAlarmDto.Request request) {
+		Map<String, String> parameters = Map.of("postType", request.getPostType(), "postWriter",
+			request.getPostWriter(),
+			"commentWriter", request.getCommentWriter(), "applicant", request.getApplicant());
+		return Alarm.builder()
+			.receiverId(request.getReceiverId())
+			.isRead(false)
+			.trashed(false)
+			.alarmInfo(convertToAlarmInfo(AlarmTemplate.valueOf(request.getAlarmType().toUpperCase()), parameters))
+			.build();
+	}
+
+	public static AlarmInfo convertToAlarmInfo(AlarmTemplate template, Map<String, String> parameters) {
+		return AlarmInfoParser.get(template, parameters);
+	}
+}

--- a/src/main/java/com/brainpix/alarm/converter/GetAlarmConverter.java
+++ b/src/main/java/com/brainpix/alarm/converter/GetAlarmConverter.java
@@ -1,0 +1,34 @@
+package com.brainpix.alarm.converter;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.brainpix.alarm.dto.GetAlarmDto;
+import com.brainpix.alarm.model.Alarm;
+
+public class GetAlarmConverter {
+
+	public static GetAlarmDto.Response convertToResponse(Page<Alarm> alarmPage) {
+		List<GetAlarmDto.AlarmDetail> alarmList = alarmPage.stream().map(GetAlarmConverter::convertToAlarmDetail).toList();
+		return GetAlarmDto.Response
+			.builder()
+			.alarmDetailList(alarmList)
+			.listSize(alarmList.size())
+			.isLast(alarmPage.isLast())
+			.totalPage(alarmPage.getTotalPages())
+			.totalElements(alarmPage.getTotalElements())
+			.build();
+	}
+
+	public static GetAlarmDto.AlarmDetail convertToAlarmDetail(Alarm alarm) {
+		return GetAlarmDto.AlarmDetail
+			.builder()
+			.alarmId(alarm.getId())
+			.header(alarm.getAlarmInfo().getHeader())
+			.message(alarm.getAlarmInfo().getMessage())
+			.redirectUrl(alarm.getAlarmInfo().getRedirectUrl())
+			.isRead(alarm.getIsRead())
+			.build();
+	}
+}

--- a/src/main/java/com/brainpix/alarm/dto/CreateAlarmDto.java
+++ b/src/main/java/com/brainpix/alarm/dto/CreateAlarmDto.java
@@ -1,0 +1,24 @@
+package com.brainpix.alarm.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class CreateAlarmDto {
+
+	@Getter
+	@Builder
+	public static class Request {
+		private Long receiverId;
+		private String alarmType;
+		private String postType;
+		private String postWriter;
+		private String commentWriter;
+		private String applicant;
+	}
+
+	@Getter
+	@Builder
+	public static class Response {
+		private String alarmId;
+	}
+}

--- a/src/main/java/com/brainpix/alarm/dto/GetAlarmDto.java
+++ b/src/main/java/com/brainpix/alarm/dto/GetAlarmDto.java
@@ -1,0 +1,38 @@
+package com.brainpix.alarm.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 읽지 않은 알람을 가져오는 API 의 응답 DTO
+ */
+public class GetAlarmDto {
+
+	/**
+	 * 읽지 않은 알람을 가져오는 API 의 응답
+	 */
+	@Getter
+	@Builder
+	public static class Response {
+		private Integer totalPage;
+		private Long totalElements;
+		private Integer listSize;
+		private Boolean isLast;
+		private List<AlarmDetail> alarmDetailList;
+	}
+
+	/**
+	 * 알람 상세 정보
+	 */
+	@Getter
+	@Builder
+	public static class AlarmDetail {
+		private String alarmId;
+		private Boolean isRead;
+		private String header;
+		private String message;
+		private String redirectUrl;
+	}
+}

--- a/src/main/java/com/brainpix/alarm/dto/GetUnreadAlarmDto.java
+++ b/src/main/java/com/brainpix/alarm/dto/GetUnreadAlarmDto.java
@@ -1,0 +1,13 @@
+package com.brainpix.alarm.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class GetUnreadAlarmDto {
+
+	@Getter
+	@Builder
+	public static class Response {
+		private Long alarmCount;
+	}
+}

--- a/src/main/java/com/brainpix/alarm/model/Alarm.java
+++ b/src/main/java/com/brainpix/alarm/model/Alarm.java
@@ -1,0 +1,35 @@
+package com.brainpix.alarm.model;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.brainpix.jpa.BaseTimeEntity;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Document(collection = "alarm")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Alarm extends BaseTimeEntity {
+
+	@Id
+	private String id;
+
+	private Long receiverId;
+
+	private Boolean isRead;
+
+	private Boolean trashed;
+
+	private AlarmInfo alarmInfo;
+
+	public void readAlarm() {
+		this.isRead = true;
+	}
+}

--- a/src/main/java/com/brainpix/alarm/model/Alarm.java
+++ b/src/main/java/com/brainpix/alarm/model/Alarm.java
@@ -32,4 +32,12 @@ public class Alarm extends BaseTimeEntity {
 	public void readAlarm() {
 		this.isRead = true;
 	}
+
+	public void addTrash() {
+		this.trashed = true;
+	}
+
+	public void restore() {
+		this.trashed = false;
+	}
 }

--- a/src/main/java/com/brainpix/alarm/model/AlarmInfo.java
+++ b/src/main/java/com/brainpix/alarm/model/AlarmInfo.java
@@ -1,0 +1,13 @@
+package com.brainpix.alarm.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlarmInfo {
+	private String name;
+	private String header;
+	private String message;
+	private String redirectUrl;
+}

--- a/src/main/java/com/brainpix/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/brainpix/alarm/repository/AlarmRepository.java
@@ -1,5 +1,7 @@
 package com.brainpix.alarm.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -8,6 +10,8 @@ import com.brainpix.alarm.model.Alarm;
 
 public interface AlarmRepository extends MongoRepository<Alarm, String> {
 	Page<Alarm> findByReceiverIdAndTrashed(Long receiverId, boolean trashed, Pageable pageable);
+
+	List<Alarm> findAllByReceiverIdAndTrashed(Long receiverId, boolean trashed);
 
 	Long countAlarmByReceiverIdAndIsRead(Long receiverId, Boolean isRead);
 }

--- a/src/main/java/com/brainpix/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/brainpix/alarm/repository/AlarmRepository.java
@@ -1,0 +1,13 @@
+package com.brainpix.alarm.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.brainpix.alarm.model.Alarm;
+
+public interface AlarmRepository extends MongoRepository<Alarm, String> {
+	Page<Alarm> findByReceiverIdAndTrashed(Long receiverId, boolean trashed, Pageable pageable);
+
+	Long countAlarmByReceiverIdAndIsRead(Long receiverId, Boolean isRead);
+}

--- a/src/main/java/com/brainpix/alarm/service/AlarmService.java
+++ b/src/main/java/com/brainpix/alarm/service/AlarmService.java
@@ -1,5 +1,8 @@
 package com.brainpix.alarm.service;
 
+import java.util.List;
+import java.util.Objects;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -29,9 +32,8 @@ public class AlarmService {
 	 * @param alarmId 알림 ID
 	 * @throws BrainPixException 알림이 이미 읽음 처리된 경우
 	 */
-	public void readAlarm(String alarmId) {
-		Alarm alarm = alarmRepository.findById(alarmId)
-			.orElseThrow(() -> new BrainPixException(AlarmErrorCode.ALARM_NOT_FOUND));
+	public void readAlarm(String alarmId, Long userId) {
+		Alarm alarm = getAlarm(alarmId, userId);
 
 		if (alarm.getIsRead()) {
 			throw new BrainPixException(AlarmErrorCode.ALARM_ALREADY_READ);
@@ -48,8 +50,7 @@ public class AlarmService {
 	 */
 	public GetAlarmDto.Response getAlarm(Pageable pageable, Long receiverId) {
 		// sort 추가하여 isRead = false 먼저 보여줌
-		PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-			Sort.by(Sort.Order.asc("isRead"), Sort.Order.desc("createdAt")));
+		PageRequest pageRequest = getPageRequestOrderByCreatedAt(pageable);
 
 		Page<Alarm> alarmPage = alarmRepository.findByReceiverIdAndTrashed(receiverId, false, pageRequest);
 
@@ -63,8 +64,7 @@ public class AlarmService {
 	 * @return GetAlarmDto.Response
 	 */
 	public GetAlarmDto.Response getTrashAlarm(Pageable pageable, Long receiverId) {
-		PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
-			Sort.by(Sort.Order.desc("createdAt")));
+		PageRequest pageRequest = getPageRequestOrderByCreatedAt(pageable);
 
 		Page<Alarm> alarmPage = alarmRepository.findByReceiverIdAndTrashed(receiverId, true, pageRequest);
 
@@ -95,5 +95,92 @@ public class AlarmService {
 		Long alarmCount = alarmRepository.countAlarmByReceiverIdAndIsRead(userId, false);
 
 		return GetUnreadAlarmDto.Response.builder().alarmCount(alarmCount).build();
+	}
+
+	/**
+	 * 알림을 휴지통으로 보냅니다
+	 * @param alarmId 알림 ID
+	 * @param userId 사용자 ID
+	 */
+	public void addTrashAlarm(String alarmId, Long userId) {
+		Alarm alarm = getAlarm(alarmId, userId);
+
+		if (alarm.getTrashed()) {
+			throw new BrainPixException(AlarmErrorCode.ALARM_ALREADY_TRASHED);
+		}
+
+		alarm.addTrash();
+
+		alarmRepository.save(alarm);
+	}
+
+	/**
+	 * 휴지통에서 알림을 복원합니다
+	 * @param alarmId 알림 ID
+	 * @param userId 사용자 ID
+	 */
+	public void restoreAlarm(String alarmId, Long userId) {
+		Alarm alarm = getAlarm(alarmId, userId);
+
+		if (!alarm.getTrashed()) {
+			throw new BrainPixException(AlarmErrorCode.ALARM_NOT_TRASHED);
+		}
+
+		alarm.restore();
+
+		alarmRepository.save(alarm);
+	}
+
+	/**
+	 * 하나의 알림을 삭제합니다
+	 * @param alarmId 알림 ID
+	 * @param userId 사용자 ID
+	 */
+	public void deleteOneAlarm(String alarmId, Long userId) {
+		Alarm alarm = getAlarm(alarmId, userId);
+
+		if (!alarm.getTrashed()) {
+			throw new BrainPixException(AlarmErrorCode.ALARM_NOT_TRASHED);
+		}
+
+		alarmRepository.delete(alarm);
+	}
+
+	/**
+	 * 휴지통에 있는 모든 알림을 삭제합니다
+	 * @param userId 사용자 ID
+	 */
+	public void deleteAllAlarm(Long userId) {
+		List<Alarm> trashedAlarm = alarmRepository.findAllByReceiverIdAndTrashed(userId, true);
+
+		alarmRepository.deleteAll(trashedAlarm);
+	}
+
+	/**
+	 * 알림 ID로 알림을 조회합니다
+	 * @param alarmId 알림 ID
+	 * @param userId 사용자 ID
+	 * @throws BrainPixException 알림이 존재하지 않거나 알림 수신자가 아닌 경우
+	 * @return Alarm
+	 */
+	private Alarm getAlarm(String alarmId, Long userId) {
+		Alarm alarm = alarmRepository.findById(alarmId)
+			.orElseThrow(() -> new BrainPixException(AlarmErrorCode.ALARM_NOT_FOUND));
+
+		if (!Objects.equals(alarm.getReceiverId(), userId)) {
+			throw new BrainPixException(AlarmErrorCode.NOT_ALARM_RECEIVER);
+		}
+
+		return alarm;
+	}
+
+	/**
+	 * 생성일자를 기준으로 내림차순 정렬이 추가된 PageRequest를 반환합니다
+	 * @param pageable 페이징 정보
+	 * @return PageRequest
+	 */
+	private PageRequest getPageRequestOrderByCreatedAt(Pageable pageable) {
+		return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+			Sort.by(Sort.Order.desc("createdAt")));
 	}
 }

--- a/src/main/java/com/brainpix/alarm/service/AlarmService.java
+++ b/src/main/java/com/brainpix/alarm/service/AlarmService.java
@@ -1,0 +1,99 @@
+package com.brainpix.alarm.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import com.brainpix.alarm.converter.CreateAlarmConverter;
+import com.brainpix.alarm.converter.GetAlarmConverter;
+import com.brainpix.alarm.dto.CreateAlarmDto;
+import com.brainpix.alarm.dto.GetAlarmDto;
+import com.brainpix.alarm.dto.GetUnreadAlarmDto;
+import com.brainpix.alarm.model.Alarm;
+import com.brainpix.alarm.repository.AlarmRepository;
+import com.brainpix.api.code.error.AlarmErrorCode;
+import com.brainpix.api.exception.BrainPixException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+
+	private final AlarmRepository alarmRepository;
+
+	/**
+	 * 알림을 읽음 처리합니다
+	 * @param alarmId 알림 ID
+	 * @throws BrainPixException 알림이 이미 읽음 처리된 경우
+	 */
+	public void readAlarm(String alarmId) {
+		Alarm alarm = alarmRepository.findById(alarmId)
+			.orElseThrow(() -> new BrainPixException(AlarmErrorCode.ALARM_NOT_FOUND));
+
+		if (alarm.getIsRead()) {
+			throw new BrainPixException(AlarmErrorCode.ALARM_ALREADY_READ);
+		}
+		alarm.readAlarm();
+		alarmRepository.save(alarm);
+	}
+
+	/**
+	 * 알림 목록을 조회합니다
+	 * <p>조회한 알람을 우선순위로 정렬하여 반환합니다</p>
+	 * @param pageable 페이징 정보(페이지 번호, 페이지 크기)
+	 * @return GetAlarmDto.Response
+	 */
+	public GetAlarmDto.Response getAlarm(Pageable pageable, Long receiverId) {
+		// sort 추가하여 isRead = false 먼저 보여줌
+		PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+			Sort.by(Sort.Order.asc("isRead"), Sort.Order.desc("createdAt")));
+
+		Page<Alarm> alarmPage = alarmRepository.findByReceiverIdAndTrashed(receiverId, false, pageRequest);
+
+		return GetAlarmConverter.convertToResponse(alarmPage);
+	}
+
+	/**
+	 * 휴지통 알림 목록을 조회합니다
+	 * <p>휴지통에 있는 알람을 생성일자로 정렬하여 반환합니다</p>
+	 * @param pageable 페이징 정보(페이지 번호, 페이지 크기)
+	 * @return GetAlarmDto.Response
+	 */
+	public GetAlarmDto.Response getTrashAlarm(Pageable pageable, Long receiverId) {
+		PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+			Sort.by(Sort.Order.desc("createdAt")));
+
+		Page<Alarm> alarmPage = alarmRepository.findByReceiverIdAndTrashed(receiverId, true, pageRequest);
+
+		return GetAlarmConverter.convertToResponse(alarmPage);
+	}
+
+	/**
+	 * 알림을 생성합니다
+	 * @param request 알림 생성 요청 정보
+	 * @return CreateAlarmDto.Response
+	 */
+	public CreateAlarmDto.Response createAlarm(CreateAlarmDto.Request request) {
+
+		Alarm alarm = CreateAlarmConverter.convertToAlarm(request);
+
+		alarmRepository.save(alarm);
+
+		return CreateAlarmDto.Response.builder().alarmId(alarm.getId()).build();
+	}
+
+	/**
+	 * 읽지 않은 알림 개수를 조회합니다
+	 * @param userId 알람 수신 사용자 ID
+	 * @return GetUnreadAlarmDto.Response
+	 */
+	public GetUnreadAlarmDto.Response getUnreadAlarmCount(Long userId) {
+
+		Long alarmCount = alarmRepository.countAlarmByReceiverIdAndIsRead(userId, false);
+
+		return GetUnreadAlarmDto.Response.builder().alarmCount(alarmCount).build();
+	}
+}

--- a/src/main/java/com/brainpix/alarm/template/AlarmTemplate.java
+++ b/src/main/java/com/brainpix/alarm/template/AlarmTemplate.java
@@ -1,0 +1,27 @@
+package com.brainpix.alarm.template;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmTemplate {
+	// Q&A 관련
+	QNA_COMMENT("${postType} > 담당자 Q&A", "${postWriter}님의 게시글에 ${commentWriter}님이 댓글을 남겼습니다.", "url 주소"),
+	QNA_COMMENT_REPLY("${postType} > 담당자 Q&A", "${postWriter}님의 게시글에 ${commentWriter}님이 댓글을 남겼습니다.", "url 주소"),
+
+	// 아이디어 마켓 관련
+	IDEA_SOLD("아이디어 마켓", "${postWriter}님의 아이디어가 판매되었습니다.", "url 주소"),
+
+	// 요청 과제 관련
+	REQUEST_TASK_APPLY("요청 과제", "${postWriter}님의 과제에 ${applicant}님이 지원하셨습니다.", "url 주소"),
+	REQUEST_TASK_APPROVE("요청 과제", "${applicant}님이 지원하신 과제가 승낙 되었습니다", "url 주소"),
+
+	// 협업 광장 관련
+	COLLABORATION_TASK_APPLY("협업 광장", "${applicant}님이 ${postWriter}님의 팀에 지원하셨습니다", "url 주소"),
+	COLLABORATION_TASK_APPROVE("협업 광장", "${applicant}님이 팀${postWriter}에 승인 되었습니다", "url 주소"),
+	COLLABORATION_TASK_REJECT("협업 광장", "${applicant}님이 팀${postWriter}에 거절 되었습니다", "url 주소");
+	private final String messageTemplate;
+	private final String headerTemplate;
+	private final String redirectUrl;
+}

--- a/src/main/java/com/brainpix/alarm/utils/AlarmInfoParser.java
+++ b/src/main/java/com/brainpix/alarm/utils/AlarmInfoParser.java
@@ -1,0 +1,24 @@
+package com.brainpix.alarm.utils;
+
+import java.util.Map;
+
+import com.brainpix.alarm.template.AlarmTemplate;
+import com.brainpix.alarm.model.AlarmInfo;
+
+public class AlarmInfoParser {
+
+	public static AlarmInfo get(AlarmTemplate template, Map<String, String> params) {
+		String message = parseTemplate(template.getMessageTemplate(), params);
+		String header = parseTemplate(template.getHeaderTemplate(), params);
+		String redirectUrl = parseTemplate(template.getRedirectUrl(), params);
+		return AlarmInfo.builder().name(template.name()).header(header).message(message).redirectUrl(redirectUrl).build();
+	}
+
+	private static String parseTemplate(String template, Map<String, String> params) {
+		String parsedTemplate = template;
+		for (String key : params.keySet()) {
+			parsedTemplate = parsedTemplate.replace("${" + key + "}", params.get(key));
+		}
+		return parsedTemplate;
+	}
+}

--- a/src/main/java/com/brainpix/api/code/error/AlarmErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/AlarmErrorCode.java
@@ -11,7 +11,11 @@ public enum AlarmErrorCode implements ErrorCode {
 	ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM404", "알림을 찾을 수 없습니다."),
 
 	ALARM_ALREADY_READ(HttpStatus.BAD_REQUEST, "ALARM400", "이미 읽은 알림입니다."),
-	;
+	NOT_ALARM_RECEIVER(HttpStatus.BAD_REQUEST, "ALARM400", "알림 수신자가 아닙니다."),
+
+	ALARM_ALREADY_TRASHED(HttpStatus.BAD_REQUEST, "ALARM400", "이미 휴지통에 있는 알림입니다."),
+	ALARM_NOT_TRASHED(HttpStatus.BAD_REQUEST, "ALARM400", "휴지통에 없는 알림입니다.");
+	
 	private final HttpStatus httpStatus;
 	private final String code;
 	private final String message;

--- a/src/main/java/com/brainpix/api/code/error/AlarmErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/AlarmErrorCode.java
@@ -1,0 +1,18 @@
+package com.brainpix.api.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmErrorCode implements ErrorCode {
+	ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM404", "알림을 찾을 수 없습니다."),
+
+	ALARM_ALREADY_READ(HttpStatus.BAD_REQUEST, "ALARM400", "이미 읽은 알림입니다."),
+	;
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/brainpix/config/MongoConfig.java
+++ b/src/main/java/com/brainpix/config/MongoConfig.java
@@ -1,0 +1,14 @@
+package com.brainpix.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@Configuration
+@EnableMongoAuditing
+public class MongoConfig extends AbstractMongoClientConfiguration {
+	@Override
+	protected String getDatabaseName() {
+		return "brainpix";
+	}
+}

--- a/src/main/java/com/brainpix/jpa/JpaConfig.java
+++ b/src/main/java/com/brainpix/jpa/JpaConfig.java
@@ -1,10 +1,16 @@
 package com.brainpix.jpa;
 
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import com.brainpix.alarm.repository.AlarmRepository;
 
 @Configuration
 @EnableJpaAuditing
+@EnableJpaRepositories(excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = AlarmRepository.class))
 public class JpaConfig {
-	
+
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #7 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
알림 관련 프로토타입 구현하였습니다
### mongodb의존성 관련
mongodb 의존성 추가로 인해 빌드시 실패할 수도 있습니다
mongodb 설치후 실행시킨 다음에 아래와 같이 프로퍼티 입력해 주셔야 합니다
```yml
spring.data.mongodb.uri=mongodb://localhost:27017/brainpix
```
mongodb config 파일에 데이터베이스 이름을 brainpix로 설정하였으니 mongodb compass 설치하신 후 gui로 brainpix이름을 가진 데이터베이스 추가하시면 됩니다
### jpa configuration 수정사항
AlarmRepository가 jpa repository로 잡히는 문제가 있어서 excludeFilter로 AlarmRepository를 jpa repository에서 제거했습니다
### 알림 저장 관련
알림 저장은 일단 api로 구현하였는데 추후 util 클래스로 추가할 예정입니다
테스트용 api라 util 클래스 추가되면 사용하시면 될것같습니다