### PR TITLE
[CICD] 빌드된 jar파일 경로 설정 (#15)

### DIFF
--- a/.github/workflows/develop_cd_workflow.yml
+++ b/.github/workflows/develop_cd_workflow.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'openjdk'
+          distribution: 'adopt'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -41,12 +41,11 @@ jobs:
       - name: docker build and push
         uses: docker/build-push-action@v5.1.0
         with:
+          context: .
           push: true
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
           cache-to: type=inline
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ secrets.DOCKER_HUB_REPOSITORY }}:latest
-          build-args: |
-            APP_ENV=${{ secrets.JASYPT_KEY }}
   
   deploy:
     runs-on: brainpix_self-hosted_runner

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com'
-version = '0.0.1-SNAPSHOT'
+version = '0'
 
 java {
     toolchain {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #15 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
jar파일은 ./build/libs에 되지만, 현재 경로를 잘 설정해 주어야 상대경로가 들어 맞는다.

도커를 실행하는 경로를 우리 코드의 루트가 되도록 하였다.