### PR TITLE
[FEAT] 댓글 기능이 도든 글 유형에 적용되도록 변경 (#18)

### DIFF
--- a/src/main/java/com/brainpix/post/entity/Comment.java
+++ b/src/main/java/com/brainpix/post/entity/Comment.java
@@ -1,4 +1,4 @@
-package com.brainpix.post.entity.request_task;
+package com.brainpix.post.entity;
 
 import com.brainpix.jpa.BaseTimeEntity;
 import com.brainpix.user.entity.User;
@@ -24,7 +24,7 @@ public class Comment extends BaseTimeEntity {
 	private User writer;
 
 	@ManyToOne
-	private RequestTask parentRequestTask;
+	private Post parentPost;
 
 	@ManyToOne
 	private Comment parentComment;
@@ -32,9 +32,9 @@ public class Comment extends BaseTimeEntity {
 	private String content;
 
 	@Builder
-	public Comment(User writer, RequestTask parentRequestTask, Comment parentComment, String content) {
+	public Comment(User writer, Post parentPost, Comment parentComment, String content) {
 		this.writer = writer;
-		this.parentRequestTask = parentRequestTask;
+		this.parentPost = parentPost;
 		this.parentComment = parentComment;
 		this.content = content;
 	}

--- a/src/main/java/com/brainpix/post/entity/Post.java
+++ b/src/main/java/com/brainpix/post/entity/Post.java
@@ -5,18 +5,30 @@ import java.util.List;
 import com.brainpix.jpa.BaseTimeEntity;
 import com.brainpix.user.entity.User;
 
+import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@MappedSuperclass
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
 @NoArgsConstructor
 @Getter
-public abstract class BasePost extends BaseTimeEntity {
+public abstract class Post extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
 	@ManyToOne
 	private User writer;
 
@@ -35,7 +47,7 @@ public abstract class BasePost extends BaseTimeEntity {
 	@ElementCollection
 	private List<String> attachmentFileList;
 
-	public BasePost(User writer, String title, String content, String category, Boolean openMyProfile, Long viewCount,
+	public Post(User writer, String title, String content, String category, Boolean openMyProfile, Long viewCount,
 		IdeaMarketAuth ideaMarketAuth, List<String> imageList, List<String> attachmentFileList) {
 		this.writer = writer;
 		this.title = title;

--- a/src/main/java/com/brainpix/post/entity/collaboration_hub/CollaborationHub.java
+++ b/src/main/java/com/brainpix/post/entity/collaboration_hub/CollaborationHub.java
@@ -3,14 +3,11 @@ package com.brainpix.post.entity.collaboration_hub;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.brainpix.post.entity.BasePost;
+import com.brainpix.post.entity.Post;
 import com.brainpix.post.entity.IdeaMarketAuth;
 import com.brainpix.user.entity.User;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,11 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class CollaborationHub extends BasePost {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
+public class CollaborationHub extends Post {
 	private LocalDateTime deadline;
 	private String link;
 

--- a/src/main/java/com/brainpix/post/entity/idea_market/IdeaMarket.java
+++ b/src/main/java/com/brainpix/post/entity/idea_market/IdeaMarket.java
@@ -2,8 +2,8 @@ package com.brainpix.post.entity.idea_market;
 
 import java.util.List;
 
-import com.brainpix.post.entity.BasePost;
 import com.brainpix.joining.entity.quantity.Price;
+import com.brainpix.post.entity.Post;
 import com.brainpix.post.entity.IdeaMarketAuth;
 import com.brainpix.profile.entity.Specialization;
 import com.brainpix.user.entity.User;
@@ -11,9 +11,6 @@ import com.brainpix.user.entity.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,11 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class IdeaMarket extends BasePost {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
+public class IdeaMarket extends Post {
 	private Specialization specialization;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/brainpix/post/entity/request_task/RequestTask.java
+++ b/src/main/java/com/brainpix/post/entity/request_task/RequestTask.java
@@ -3,7 +3,7 @@ package com.brainpix.post.entity.request_task;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.brainpix.post.entity.BasePost;
+import com.brainpix.post.entity.Post;
 import com.brainpix.post.entity.IdeaMarketAuth;
 import com.brainpix.post.entity.collaboration_hub.CollaborationType;
 import com.brainpix.user.entity.User;
@@ -11,9 +11,6 @@ import com.brainpix.user.entity.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,11 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class RequestTask extends BasePost {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
+public class RequestTask extends Post {
 	private LocalDateTime deadline;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/brainpix/profile/entity/Profile.java
+++ b/src/main/java/com/brainpix/profile/entity/Profile.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.brainpix.jpa.BaseTimeEntity;
 
+import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
 @NoArgsConstructor
 @Getter
 public abstract class Profile extends BaseTimeEntity {

--- a/src/main/java/com/brainpix/user/entity/User.java
+++ b/src/main/java/com/brainpix/user/entity/User.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.brainpix.jpa.BaseTimeEntity;
 import com.brainpix.profile.entity.Profile;
 
+import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
 @NoArgsConstructor
 @Getter
 public abstract class User extends BaseTimeEntity {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #18 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
댓글 기능이 도든 글 유형에 적용되도록 엔티티를 변경했습니다.

기존에는 글의 공통적인 부분을 BasePost 클래스로 묶고,  MappedSuperClass를 이용해 데이터베이스 테이블에는 하나의 테이블로 인식되지 않게했습니다.

그러나 댓글기능이 모든 글 유형에(기존에는 요청 과제에만 댓글 기능이 있었음) 있음에 따라, BasePost 클래스를 Inheritance의 조인 방식으로 엔티티를 변경하였습니다. 이에 따라 댓글 기능을 1번만 개발하면, 3개의 다른 글 유형에 동일하게 적용될 수 있습니다.
