### PR TITLE
[BUG] JpaConfig에 basePackages를 명시하여 리포지토리가 스캔되도록 합니다. (#21)

### DIFF
--- a/src/main/java/com/brainpix/jpa/JpaConfig.java
+++ b/src/main/java/com/brainpix/jpa/JpaConfig.java
@@ -10,7 +10,7 @@ import com.brainpix.alarm.repository.AlarmRepository;
 
 @Configuration
 @EnableJpaAuditing
-@EnableJpaRepositories(excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = AlarmRepository.class))
+@EnableJpaRepositories(basePackages = {"com.brainpix"}, excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = AlarmRepository.class))
 public class JpaConfig {
 
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #21 

## ✨ PR 세부 내용

문제 상황 : 
com/brainpix/jpa에 위치한 JpaConfig에서 @EnableJpaRepositories를 사용하는 경우,
상위 폴더에 BrainpixApplication이 있음에도 JPA 리포지토리들을 스캔하지 못하는 버그가 발생하였습니다.

해결 방법 :
JpaConfig 속성 값으로 basePackages = {"com.brainpix"} 를 추가하여 리포지토리를 인식하도록 하였습니다.