### PR TITLE
[FIX] Post 카테고리와 관련된 부분을 수정합니다 (#36)

### DIFF
--- a/src/main/java/com/brainpix/post/entity/Post.java
+++ b/src/main/java/com/brainpix/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.brainpix.post.entity;
 import java.util.List;
 
 import com.brainpix.jpa.BaseTimeEntity;
+import com.brainpix.profile.entity.Specialization;
 import com.brainpix.user.entity.User;
 
 import jakarta.persistence.DiscriminatorColumn;
@@ -34,12 +35,14 @@ public abstract class Post extends BaseTimeEntity {
 
 	private String title;
 	private String content;
-	private String category;
 	private Boolean openMyProfile;
 	private Long viewCount;
 
 	@Enumerated(EnumType.STRING)
 	private PostAuth postAuth;
+
+	@Enumerated(EnumType.STRING)
+	private Specialization specialization;
 
 	@ElementCollection
 	private List<String> imageList;
@@ -47,15 +50,15 @@ public abstract class Post extends BaseTimeEntity {
 	@ElementCollection
 	private List<String> attachmentFileList;
 
-	public Post(User writer, String title, String content, String category, Boolean openMyProfile, Long viewCount,
-		PostAuth postAuth, List<String> imageList, List<String> attachmentFileList) {
+	public Post(User writer, String title, String content, Boolean openMyProfile, Long viewCount,
+		PostAuth postAuth, Specialization specialization,List<String> imageList, List<String> attachmentFileList) {
 		this.writer = writer;
 		this.title = title;
 		this.content = content;
-		this.category = category;
 		this.openMyProfile = openMyProfile;
 		this.viewCount = viewCount;
 		this.postAuth = postAuth;
+		this.specialization = specialization;
 		this.imageList = imageList;
 		this.attachmentFileList = attachmentFileList;
 	}

--- a/src/main/java/com/brainpix/post/entity/collaboration_hub/CollaborationHub.java
+++ b/src/main/java/com/brainpix/post/entity/collaboration_hub/CollaborationHub.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.brainpix.post.entity.Post;
 import com.brainpix.post.entity.PostAuth;
+import com.brainpix.profile.entity.Specialization;
 import com.brainpix.user.entity.User;
 
 import jakarta.persistence.Entity;
@@ -20,10 +21,10 @@ public class CollaborationHub extends Post {
 	private String link;
 
 	@Builder
-	public CollaborationHub(User writer, String title, String content, String category, Boolean openMyProfile,
+	public CollaborationHub(User writer, String title, String content, Boolean openMyProfile,
 		Long viewCount, List<String> imageList, List<String> attachmentFileList, LocalDateTime deadline,
-		String link, PostAuth postAuth) {
-		super(writer, title, content, category, openMyProfile, viewCount, postAuth, imageList,
+		String link, PostAuth postAuth, Specialization specialization) {
+		super(writer, title, content, openMyProfile, viewCount, postAuth, specialization, imageList,
 			attachmentFileList);
 		this.deadline = deadline;
 		this.link = link;

--- a/src/main/java/com/brainpix/post/entity/idea_market/IdeaMarket.java
+++ b/src/main/java/com/brainpix/post/entity/idea_market/IdeaMarket.java
@@ -20,7 +20,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class IdeaMarket extends Post {
-	private Specialization specialization;
 
 	@Enumerated(EnumType.STRING)
 	private IdeaMarketType ideaMarketType;
@@ -29,12 +28,11 @@ public class IdeaMarket extends Post {
 	private Price price;
 
 	@Builder
-	public IdeaMarket(User writer, String title, String content, String category, Boolean openMyProfile, Long viewCount,
+	public IdeaMarket(User writer, String title, String content, Boolean openMyProfile, Long viewCount,
 		List<String> imageList, PostAuth postAuth, List<String> attachmentFileList,
 		Specialization specialization, IdeaMarketType ideaMarketType, Price price) {
-		super(writer, title, content, category, openMyProfile, viewCount, postAuth, imageList,
+		super(writer, title, content, openMyProfile, viewCount, postAuth, specialization, imageList,
 			attachmentFileList);
-		this.specialization = specialization;
 		this.ideaMarketType = ideaMarketType;
 		this.price = price;
 	}

--- a/src/main/java/com/brainpix/post/entity/request_task/RequestTask.java
+++ b/src/main/java/com/brainpix/post/entity/request_task/RequestTask.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.brainpix.post.entity.Post;
 import com.brainpix.post.entity.PostAuth;
+import com.brainpix.profile.entity.Specialization;
 import com.brainpix.user.entity.User;
 
 import jakarta.persistence.Entity;
@@ -24,10 +25,10 @@ public class RequestTask extends Post {
 	private RequestTaskType requestTaskType;
 
 	@Builder
-	public RequestTask(User writer, String title, String content, String category, Boolean openMyProfile,
+	public RequestTask(User writer, String title, String content, Boolean openMyProfile,
 		Long viewCount, List<String> imageList, List<String> attachmentFileList, LocalDateTime deadline,
-		RequestTaskType requestTaskType, PostAuth postAuth) {
-		super(writer, title, content, category, openMyProfile, viewCount, postAuth, imageList,
+		RequestTaskType requestTaskType, PostAuth postAuth, Specialization specialization) {
+		super(writer, title, content, openMyProfile, viewCount, postAuth, specialization, imageList,
 			attachmentFileList);
 		this.deadline = deadline;
 		this.requestTaskType = requestTaskType;


### PR DESCRIPTION
…협업광장 엔티티 수정

<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #36

## ✨ PR 세부 내용
1. 기존 Post 엔티티에서 String으로 받았던 Category 필드를 삭제 후 Specialization enum객체로 변경하였습니다.
2. 기존 아이디어 마켓 엔티티의 Specializtion 필드는 삭제했습니다.
3. 엔티티의 변화로 인해 Post와 상속받는 엔티티의 생성자들을 모두 수정해 주었습니다.
<!-- 수정/추가한 내용을 적어주세요. -->
