### PR TITLE
[FEAT] 초기 인원인지 확인하는 필드 추가 (#54)

### DIFF
--- a/src/main/java/com/brainpix/joining/entity/purchasing/CollectionGathering.java
+++ b/src/main/java/com/brainpix/joining/entity/purchasing/CollectionGathering.java
@@ -25,12 +25,16 @@ public class CollectionGathering extends BaseTimeEntity {
 
 	private Boolean accepted;
 
+	private Boolean initialGathering;
+
 	@ManyToOne
 	private CollaborationRecruitment collaborationRecruitment;
 
-	public CollectionGathering(User joiner, Boolean accepted, CollaborationRecruitment collaborationRecruitment) {
+	public CollectionGathering(User joiner, Boolean accepted, Boolean initialGathering,
+		CollaborationRecruitment collaborationRecruitment) {
 		this.joiner = joiner;
 		this.accepted = accepted;
+		this.initialGathering = initialGathering;
 		this.collaborationRecruitment = collaborationRecruitment;
 	}
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #54 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
협업 광장에서 개최인원을 보여주는 로직이 있기 때문에, 협업 광장 참여 엔티티에 개최인원인지를 나타내는 필드를 추가하였습니다
![image](https://github.com/user-attachments/assets/7955b599-0de8-4b97-9f07-0314815bf26a)


