### PR TITLE
[FEAT] 협업 광장 전체 조회 및 상세 조회 구현 (#35)

### DIFF
--- a/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
@@ -16,6 +16,7 @@ public interface CollectionGatheringRepository extends JpaRepository<CollectionG
 	// 개최 인원 등록 정보 조회
 	@Query("SELECT cg FROM CollectionGathering cg " +
 		"JOIN FETCH cg.collaborationRecruitment cr " +
-		"WHERE cr.parentCollaborationHub.id = :collaborationHubId")
+		"WHERE cr.parentCollaborationHub.id = :collaborationHubId " +
+		"AND cg.initialGathering = true")
 	List<CollectionGathering> findByCollaborationHubId(@Param("collaborationHubId") Long collaborationHubId);
 }

--- a/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
@@ -1,6 +1,10 @@
 package com.brainpix.joining.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.brainpix.joining.entity.purchasing.CollectionGathering;
 
@@ -8,4 +12,10 @@ public interface CollectionGatheringRepository extends JpaRepository<CollectionG
 
 	// 협업 횟수 조회 (승낙된 협업)
 	Long countByJoinerIdAndAccepted(Long joinerId, Boolean accepted);
+
+	// 개최 인원 등록 정보 조회
+	@Query("SELECT cg FROM CollectionGathering cg " +
+		"JOIN FETCH cg.collaborationRecruitment cr " +
+		"WHERE cr.parentCollaborationHub.id = :collaborationHubId")
+	List<CollectionGathering> findByCollaborationHubId(@Param("collaborationHubId") Long collaborationHubId);
 }

--- a/src/main/java/com/brainpix/post/controller/CollaborationHubController.java
+++ b/src/main/java/com/brainpix/post/controller/CollaborationHubController.java
@@ -3,11 +3,14 @@ package com.brainpix.post.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.brainpix.api.ApiResponse;
+import com.brainpix.post.converter.GetCollaborationHubDetailDtoConverter;
 import com.brainpix.post.converter.GetCollaborationHubListDtoConverter;
+import com.brainpix.post.dto.GetCollaborationHubDetailDto;
 import com.brainpix.post.dto.GetCollaborationHubListDto;
 import com.brainpix.post.service.CollaborationHubService;
 
@@ -29,4 +32,12 @@ public class CollaborationHubController {
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
+	@GetMapping("/{collaborationId}")
+	public ResponseEntity<ApiResponse<GetCollaborationHubDetailDto.Response>> getCollaborationHubDetail(
+		@PathVariable("collaborationId") Long collaborationId) {
+		GetCollaborationHubDetailDto.Parameter parameter = GetCollaborationHubDetailDtoConverter.toParameter(
+			collaborationId);
+		GetCollaborationHubDetailDto.Response response = collaborationHubService.getCollaborationHubDetail(parameter);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
 }

--- a/src/main/java/com/brainpix/post/controller/CollaborationHubController.java
+++ b/src/main/java/com/brainpix/post/controller/CollaborationHubController.java
@@ -1,0 +1,32 @@
+package com.brainpix.post.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.brainpix.api.ApiResponse;
+import com.brainpix.post.converter.GetCollaborationHubListDtoConverter;
+import com.brainpix.post.dto.GetCollaborationHubListDto;
+import com.brainpix.post.service.CollaborationHubService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/collaborations")
+@RequiredArgsConstructor
+public class CollaborationHubController {
+
+	private final CollaborationHubService collaborationHubService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<GetCollaborationHubListDto.Response>> getCollaborationHubList(
+		GetCollaborationHubListDto.Request request, Pageable pageable) {
+		GetCollaborationHubListDto.Parameter parameter = GetCollaborationHubListDtoConverter.toParameter(request,
+			pageable);
+		GetCollaborationHubListDto.Response response = collaborationHubService.getCollaborationHubList(parameter);
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+}

--- a/src/main/java/com/brainpix/post/converter/GetCollaborationHubDetailDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetCollaborationHubDetailDtoConverter.java
@@ -27,15 +27,19 @@ public class GetCollaborationHubDetailDtoConverter {
 		// 작성자
 		GetCollaborationHubDetailDto.Writer writerDto = toWriter(writer, totalIdeas, totalCollaborations);
 
-		// 모집 단위
-		List<GetCollaborationHubDetailDto.Recruitment> recruitments = collaborationHub.getCollaborations().stream()
-			.map(GetCollaborationHubDetailDtoConverter::toRecruitment)
-			.toList();
-
 		// 데드라인 계산
 		LocalDateTime deadline = collaborationHub.getDeadline();
 		LocalDateTime now = LocalDateTime.now();
 		Long days = deadline.isBefore(now) ? 0L : ChronoUnit.DAYS.between(now, deadline);
+
+		// 모집 단위 (개최 인원에 속하지 않는 모집 단위만 필터링)
+		List<GetCollaborationHubDetailDto.Recruitment> recruitments = collaborationHub.getCollaborations().stream()
+			.filter(recruitment ->
+				collectionGathering.stream()
+					.noneMatch(gathering -> gathering.getCollaborationRecruitment().equals(recruitment))
+			)
+			.map(GetCollaborationHubDetailDtoConverter::toRecruitment)
+			.toList();
 
 		// 개최 인원
 		List<GetCollaborationHubDetailDto.OpenMember> openMembers = collectionGathering.stream()

--- a/src/main/java/com/brainpix/post/converter/GetCollaborationHubListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetCollaborationHubListDtoConverter.java
@@ -1,0 +1,87 @@
+package com.brainpix.post.converter;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.brainpix.api.code.error.CommonErrorCode;
+import com.brainpix.api.exception.BrainPixException;
+import com.brainpix.post.dto.GetCollaborationHubListDto;
+import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
+import com.brainpix.post.enums.SortType;
+import com.brainpix.profile.entity.Specialization;
+
+public class GetCollaborationHubListDtoConverter {
+	public static GetCollaborationHubListDto.Parameter toParameter(GetCollaborationHubListDto.Request request,
+		Pageable pageable) {
+
+		Specialization category = null;
+		SortType sortType = null;
+
+		try {
+			category =
+				request.getCategory() != null ? Specialization.valueOf(request.getCategory().toUpperCase()) : null;
+			sortType = request.getSortType() != null ?
+				SortType.valueOf("COLLABORATION_" + request.getSortType().toUpperCase()) : null;
+		} catch (Exception e) {
+			throw new BrainPixException(CommonErrorCode.INVALID_PARAMETER);
+		}
+
+		return GetCollaborationHubListDto.Parameter.builder()
+			.keyword(request.getKeyword())
+			.category(category)
+			.onlyCompany(request.getOnlyCompany())
+			.sortType(sortType)
+			.pageable(pageable)
+			.build();
+	}
+
+	public static GetCollaborationHubListDto.Response toResponse(Page<Object[]> CollaborationHubs) {
+
+		List<GetCollaborationHubListDto.CollaborationDetail> collaborationDetailList = CollaborationHubs.stream()
+			.map(CollaborationHub -> {
+					CollaborationHub collaboration = (CollaborationHub)CollaborationHub[0];    // 실제 엔티티 객체
+					Long saveCount = (Long)CollaborationHub[1];        // 저장 횟수
+					LocalDateTime deadline = collaboration.getDeadline();    // 마감 기한
+					LocalDateTime now = LocalDateTime.now();    // 현재 시간
+					Long days = deadline.isBefore(now) ? 0L : ChronoUnit.DAYS.between(now, deadline); // D-DAY 계산
+
+					// 현재 인원 및 모집 인원
+					Long occupiedQuantity = collaboration.getOccupiedQuantity();
+					Long totalQuantity = collaboration.getTotalQuantity();
+					return toCollaborationDetail(collaboration, saveCount, days, occupiedQuantity, totalQuantity);
+				}
+			).toList();
+
+		return GetCollaborationHubListDto.Response.builder()
+			.collaborationDetailList(collaborationDetailList)
+			.totalPages(CollaborationHubs.getTotalPages())
+			.totalElements((int)CollaborationHubs.getTotalElements())
+			.currentPage(CollaborationHubs.getNumber())
+			.currentSize(CollaborationHubs.getNumberOfElements())
+			.hasNext(CollaborationHubs.hasNext())
+			.build();
+	}
+
+	public static GetCollaborationHubListDto.CollaborationDetail toCollaborationDetail(
+		CollaborationHub CollaborationHub, Long saveCount,
+		Long deadline, Long occupiedQuantity, Long totalQuantity) {
+		return GetCollaborationHubListDto.CollaborationDetail.builder()
+			.collaborationId(CollaborationHub.getId())
+			.auth(CollaborationHub.getPostAuth().toString())
+			.writerImageUrl(CollaborationHub.getWriter().getProfileImage())
+			.writerName(CollaborationHub.getWriter().getName())
+			.thumbnailImageUrl(CollaborationHub.getImageList().get(0))
+			.title(CollaborationHub.getTitle())
+			.deadline(deadline)
+			.category(CollaborationHub.getSpecialization().toString())
+			.occupiedQuantity(occupiedQuantity)
+			.totalQuantity(totalQuantity)
+			.saveCount(saveCount)
+			.viewCount(CollaborationHub.getViewCount())
+			.build();
+	}
+}

--- a/src/main/java/com/brainpix/post/dto/GetCollaborationHubDetailDto.java
+++ b/src/main/java/com/brainpix/post/dto/GetCollaborationHubDetailDto.java
@@ -1,0 +1,66 @@
+package com.brainpix.post.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class GetCollaborationHubDetailDto {
+
+	@Builder
+	@Getter
+	public static class Parameter {
+		private Long collaborationId;    // 협업 게시글 ID
+	}
+
+	@Builder
+	@Getter
+	public static class Response {
+		private Long collaborationId;    // 협업 게시글 ID
+		private String thumbnailImageUrl;    // 썸네일 이미지 URL
+		private String category;    // 협업 게시글 카테고리
+		private String auth;    // 공개 유형 (ALL, COMPANY)
+		private String title;    // 협업 게시글 제목
+		private String content;    // 협업 게시글 내용
+		private String link;    // 링크
+		private Long deadline;    // 남은 기간
+		private Long viewCount;    // 협업 게시글 조회수
+		private Long saveCount;    // 협업 게시글 저장수
+		private LocalDate createdDate;    // 협업 게시글 작성일 (YYYY/MM/DD)
+		private Writer writer;    // 작성자
+		private List<String> attachments;    // 첨부 파일 목록
+		private List<Recruitment> recruitments;    // 모집 단위
+		private List<OpenMember> openMembers;    // 개최 인원
+	}
+
+	@Builder
+	@Getter
+	public static class Writer {
+		private Long writerId;            // 작성자의 식별자 값
+		private String name;              // 작성자 이름
+		private String profileImageUrl;   // 작성자 프로필 이미지 URL
+		private String role;              // 작성자 역할 (COMPANY, INDIVIDUAL)
+		private String specialization; // 작성자의 분야 (IT_TECH, DESIGN, ...)
+		private Long totalIdeas;       // 작성자가 등록한 협업 게시글 수
+		private Long totalCollaborations;     // 작성자가 협업한 경험 수
+	}
+
+	@Builder
+	@Getter
+	public static class Recruitment {
+		private Long recruitmentId;        // 모집 단위 식별자
+		private String domain;            // 모집 분야
+		private Long occupiedQuantity;  // 현재 인원
+		private Long totalQuantity;     // 전체 인원
+	}
+
+	@Builder
+	@Getter
+	public static class OpenMember {
+		private Long userId;    // 유저 식별자 값
+		private String name;    // 유저 이름
+		private String domain;    // 유저 역할
+		private Boolean isOpenPortfolio;    // 포트폴리오 불러오기 여부
+	}
+}

--- a/src/main/java/com/brainpix/post/dto/GetCollaborationHubListDto.java
+++ b/src/main/java/com/brainpix/post/dto/GetCollaborationHubListDto.java
@@ -1,0 +1,64 @@
+package com.brainpix.post.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.brainpix.post.enums.SortType;
+import com.brainpix.profile.entity.Specialization;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class GetCollaborationHubListDto {
+
+	@NoArgsConstructor
+	@Getter
+	@Setter
+	public static class Request {
+		private String keyword;        // 검색 키워드
+		private String category;  // 카테고리
+		private Boolean onlyCompany;  // 기업 공개 제외/기업 공개만 보기
+		private String sortType;    // 정렬 기준
+	}
+
+	@Builder
+	@Getter
+	public static class Parameter {
+		private String keyword;        // 검색 키워드
+		private Specialization category;  // 카테고리
+		private Boolean onlyCompany;  // 기업 공개 제외/기업 공개만 보기
+		private SortType sortType;    // 정렬 기준
+		private Pageable pageable;    // 페이징 기준
+	}
+
+	@Builder
+	@Getter
+	public static class Response {
+		private List<CollaborationDetail> collaborationDetailList;    // 결과 값 리스트
+		private Integer totalPages;        // 전체 페이지 수
+		private Integer totalElements;    // 전체 결과의 크기
+		private Integer currentPage;    // 현재 페이지 수
+		private Integer currentSize;    // 현재 페이지의 크기
+		private Boolean hasNext;    // 다음 페이지 존재 여부
+	}
+
+	@Builder
+	@Getter
+	public static class CollaborationDetail {
+		private Long collaborationId;                // 게시글의 식별자 값
+		private String auth;        // 공개 범위 (ALL, COMPANY)
+		private String writerImageUrl;  // 작성자 프로필 이미지 경로
+		private String writerName;      // 작성자 닉네임
+		private String thumbnailImageUrl;          // 대표 이미지 경로
+		private String title;               // 아이디어 제목
+		private Long deadline;                 // 남은 기간
+		private String category;  // 게시글의 카테고리
+		private Long occupiedQuantity;  // 현재 인원
+		private Long totalQuantity;     // 전체 인원
+		private Long saveCount;        // 저장수
+		private Long viewCount;        // 조회수
+	}
+}

--- a/src/main/java/com/brainpix/post/enums/PostBooleanExpression.java
+++ b/src/main/java/com/brainpix/post/enums/PostBooleanExpression.java
@@ -1,8 +1,10 @@
 package com.brainpix.post.enums;
 
+import java.time.LocalDateTime;
 import java.util.function.Function;
 
 import com.brainpix.post.entity.PostAuth;
+import com.brainpix.post.entity.collaboration_hub.QCollaborationHub;
 import com.brainpix.post.entity.idea_market.IdeaMarketType;
 import com.brainpix.post.entity.idea_market.QIdeaMarket;
 import com.brainpix.profile.entity.Specialization;
@@ -12,23 +14,37 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum PostBooleanExpression {
-	EXCLUDE_PRIVATE(obj -> QIdeaMarket.ideaMarket.postAuth.ne(PostAuth.ME)),
 
+	// 아이디어 관련 검색 조건
+	IDEA_EXCLUDE_PRIVATE(obj -> QIdeaMarket.ideaMarket.postAuth.ne(PostAuth.ME)),
 	IDEA_MARKET_TYPE_EQ(type -> type instanceof IdeaMarketType ?
-		QIdeaMarket.ideaMarket.ideaMarketType.eq((IdeaMarketType) type) : null
+		QIdeaMarket.ideaMarket.ideaMarketType.eq((IdeaMarketType)type) : null
+	),
+	IDEA_TITLE_CONTAINS(keyword -> keyword instanceof String ?
+		QIdeaMarket.ideaMarket.title.contains((String)keyword) : null
+	),
+	IDEA_CATEGORY_EQ(category -> category instanceof Specialization ?
+		QIdeaMarket.ideaMarket.specialization.eq((Specialization)category) : null
+	),
+	IDEA_ONLY_COMPANY(onlyCompany -> onlyCompany instanceof Boolean ?
+		(Boolean)onlyCompany ?
+			QIdeaMarket.ideaMarket.postAuth.eq(PostAuth.COMPANY) :
+			QIdeaMarket.ideaMarket.postAuth.ne(PostAuth.COMPANY) : null
 	),
 
-	TITLE_CONTAINS(keyword -> keyword instanceof String ?
-		QIdeaMarket.ideaMarket.title.contains((String) keyword) : null
+	// 협업 광장 관련 검색 조건
+	COLLABORATION_EXCLUDE_PRIVATE(obj -> QCollaborationHub.collaborationHub.postAuth.ne(PostAuth.ME)),
+	COLLABORATION_EXCLUDE_PAST(obj -> QCollaborationHub.collaborationHub.deadline.after(LocalDateTime.now())),
+	COLLABORATION_TITLE_CONTAINS(keyword -> keyword instanceof String ?
+		QCollaborationHub.collaborationHub.title.contains((String)keyword) : null
 	),
-
-	CATEGORY_EQ(category -> category instanceof Specialization ?
-		QIdeaMarket.ideaMarket.specialization.eq((Specialization) category) : null
+	COLLABORATION_CATEGORY_EQ(category -> category instanceof Specialization ?
+		QCollaborationHub.collaborationHub.specialization.eq((Specialization)category) : null
 	),
-
-	ONLY_COMPANY(onlyCompany -> onlyCompany instanceof Boolean ?
-		(Boolean) onlyCompany ?
-			QIdeaMarket.ideaMarket.postAuth.eq(PostAuth.COMPANY) : QIdeaMarket.ideaMarket.postAuth.ne(PostAuth.COMPANY) : null
+	COLLABORATION_ONLY_COMPANY(onlyCompany -> onlyCompany instanceof Boolean ?
+		(Boolean)onlyCompany ?
+			QCollaborationHub.collaborationHub.postAuth.eq(PostAuth.COMPANY) :
+			QCollaborationHub.collaborationHub.postAuth.ne(PostAuth.COMPANY) : null
 	);
 
 	private final Function<Object, BooleanExpression> expressionFunction;

--- a/src/main/java/com/brainpix/post/enums/SortType.java
+++ b/src/main/java/com/brainpix/post/enums/SortType.java
@@ -2,8 +2,8 @@ package com.brainpix.post.enums;
 
 import java.util.function.Supplier;
 
-import com.brainpix.post.entity.QPost;
 import com.brainpix.post.entity.QSavedPost;
+import com.brainpix.post.entity.collaboration_hub.QCollaborationHub;
 import com.brainpix.post.entity.idea_market.QIdeaMarket;
 import com.querydsl.core.types.OrderSpecifier;
 
@@ -11,11 +11,18 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum SortType {
-	NEWEST(QPost.post.createdAt::desc),        // 최신 순
-	OLDEST(QPost.post.createdAt::asc),        // 오래된 순
-	POPULAR(QPost.post.count()::desc),	   // 저장 순
-	HIGHST_PRICE(QIdeaMarket.ideaMarket.price.price::desc),	// 높은 가격 순
-	LOWEST_PRICE(QIdeaMarket.ideaMarket.price.price::asc);   // 낮은 가격 순
+
+	// 아이디어 관련 정렬 조건
+	IDEA_NEWEST(QIdeaMarket.ideaMarket.createdAt::desc),    // 최신 순
+	IDEA_OLDEST(QIdeaMarket.ideaMarket.createdAt::asc),    // 오래된 순
+	IDEA_POPULAR(QSavedPost.savedPost.count()::desc),    // 저장 순
+	IDEA_HIGHEST_PRICE(QIdeaMarket.ideaMarket.price.price::desc),    // 높은 가격 순
+	IDEA_LOWEST_PRICE(QIdeaMarket.ideaMarket.price.price::asc),    // 낮은 가격 순
+
+	// 협업 광장 관련 정렬 조건
+	COLLABORATION_NEWEST(QCollaborationHub.collaborationHub.createdAt::desc),    // 최신 순
+	COLLABORATION_OLDEST(QCollaborationHub.collaborationHub.createdAt::asc),    // 오래된 순
+	COLLABORATION_POPULAR(QSavedPost.savedPost.count()::desc);    // 저장 순
 
 	private final Supplier<OrderSpecifier<?>> orderSpecifierSupplier;
 

--- a/src/main/java/com/brainpix/post/repository/CollaborationHubCustomRepository.java
+++ b/src/main/java/com/brainpix/post/repository/CollaborationHubCustomRepository.java
@@ -1,0 +1,15 @@
+package com.brainpix.post.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.brainpix.post.enums.SortType;
+import com.brainpix.profile.entity.Specialization;
+
+public interface CollaborationHubCustomRepository {
+
+	// 검색 기능을 포함한 협업 광장 조회
+	Page<Object[]> findCollaborationListWithSaveCount(String keyword,
+		Specialization category,
+		Boolean onlyCompany, SortType sortType, Pageable pageable);
+}

--- a/src/main/java/com/brainpix/post/repository/CollaborationHubCustomRepositoryImpl.java
+++ b/src/main/java/com/brainpix/post/repository/CollaborationHubCustomRepositoryImpl.java
@@ -43,8 +43,7 @@ public class CollaborationHubCustomRepositoryImpl implements CollaborationHubCus
 			)
 			.reduce(BooleanExpression::and)
 			.orElse(null);
-
-		// 정렬 조건
+		
 		// 정렬 조건 (기본 값은 최신순)
 		OrderSpecifier<?> order = sortType != null ? sortType.getOrder() : SortType.COLLABORATION_NEWEST.getOrder();
 

--- a/src/main/java/com/brainpix/post/repository/CollaborationHubCustomRepositoryImpl.java
+++ b/src/main/java/com/brainpix/post/repository/CollaborationHubCustomRepositoryImpl.java
@@ -1,0 +1,85 @@
+package com.brainpix.post.repository;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.brainpix.post.entity.QSavedPost;
+import com.brainpix.post.entity.collaboration_hub.QCollaborationHub;
+import com.brainpix.post.enums.PostBooleanExpression;
+import com.brainpix.post.enums.SortType;
+import com.brainpix.profile.entity.Specialization;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CollaborationHubCustomRepositoryImpl implements CollaborationHubCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+	QCollaborationHub collaborationHub = QCollaborationHub.collaborationHub;
+	QSavedPost savedPost = QSavedPost.savedPost;
+
+	@Override
+	public Page<Object[]> findCollaborationListWithSaveCount(String keyword, Specialization category,
+		Boolean onlyCompany, SortType sortType, Pageable pageable) {
+
+		// 검색 조건
+		BooleanExpression where = Stream.of(
+				PostBooleanExpression.COLLABORATION_EXCLUDE_PRIVATE.get(null),    // 1. 비공개 제외
+				PostBooleanExpression.COLLABORATION_EXCLUDE_PAST.get(null),    // 2. 데드라인 지난 게시물 제외
+				PostBooleanExpression.COLLABORATION_TITLE_CONTAINS.get(keyword),    // 3. 검색어 필터
+				PostBooleanExpression.COLLABORATION_CATEGORY_EQ.get(category),    // 4. 카테고리 필터
+				PostBooleanExpression.COLLABORATION_ONLY_COMPANY.get(onlyCompany)    // 5. 기업 공개만, 기업 공개 제외
+			)
+			.reduce(BooleanExpression::and)
+			.orElse(null);
+
+		// 정렬 조건
+		// 정렬 조건 (기본 값은 최신순)
+		OrderSpecifier<?> order = sortType != null ? sortType.getOrder() : SortType.COLLABORATION_NEWEST.getOrder();
+
+		// 조회 결과
+		List<Tuple> queryResult = queryFactory
+			.select(collaborationHub, savedPost.count())
+			.from(collaborationHub)
+			.leftJoin(savedPost).on(collaborationHub.eq(savedPost.post))
+			.where(where)
+			.groupBy(collaborationHub)
+			.orderBy(order)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		// 카운트 쿼리
+		JPAQuery<Long> countQuery = queryFactory
+			.select(collaborationHub.count())
+			.from(collaborationHub)
+			.where(where);
+
+		// 게시글-저장수를 쌍으로 저장
+		List<Object[]> result = parsingResult(queryResult);
+
+		return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
+	}
+
+	private List<Object[]> parsingResult(List<Tuple> queryResult) {
+		return queryResult.stream()
+			.map(tuple -> {
+				Object[] objects = new Object[2];
+				objects[0] = tuple.get(collaborationHub);
+				objects[1] = tuple.get(savedPost.count());
+				return objects;
+			})
+			.toList();
+	}
+}

--- a/src/main/java/com/brainpix/post/repository/CollaborationHubRepository.java
+++ b/src/main/java/com/brainpix/post/repository/CollaborationHubRepository.java
@@ -1,0 +1,9 @@
+package com.brainpix.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
+
+public interface CollaborationHubRepository
+	extends JpaRepository<CollaborationHub, Long>, CollaborationHubCustomRepository {
+}

--- a/src/main/java/com/brainpix/post/repository/IdeaMarketCustomRepositoryImpl.java
+++ b/src/main/java/com/brainpix/post/repository/IdeaMarketCustomRepositoryImpl.java
@@ -1,9 +1,6 @@
 package com.brainpix.post.repository;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
@@ -11,7 +8,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
-import com.brainpix.post.entity.PostAuth;
 import com.brainpix.post.entity.QSavedPost;
 import com.brainpix.post.entity.idea_market.IdeaMarketType;
 import com.brainpix.post.entity.idea_market.QIdeaMarket;
@@ -38,22 +34,23 @@ public class IdeaMarketCustomRepositoryImpl implements IdeaMarketCustomRepositor
 	// ideaMarketType으로 아이디어 유형을 구분한 뒤,
 	// 검색 조건을 동적으로 적용하여 아이디어 목록을 조회합니다.
 	@Override
-	public Page<Object[]> findIdeaListWithSaveCount(IdeaMarketType ideaMarketType, String keyword, Specialization category,
+	public Page<Object[]> findIdeaListWithSaveCount(IdeaMarketType ideaMarketType, String keyword,
+		Specialization category,
 		Boolean onlyCompany, SortType sortType, Pageable pageable) {
 
 		// 검색 조건
 		BooleanExpression where = Stream.of(
-				PostBooleanExpression.EXCLUDE_PRIVATE.get(null),                // 1. 비공개 제외
+				PostBooleanExpression.IDEA_EXCLUDE_PRIVATE.get(null),                // 1. 비공개 제외
 				PostBooleanExpression.IDEA_MARKET_TYPE_EQ.get(ideaMarketType),  // 2. 아이디어 필터링 (IDEA_SOLUTION, MARKET_PLACE)
-				PostBooleanExpression.TITLE_CONTAINS.get(keyword),              // 3. 검색어 필터
-				PostBooleanExpression.CATEGORY_EQ.get(category),                // 4. 카테고리 필터
-				PostBooleanExpression.ONLY_COMPANY.get(onlyCompany)             // 5. 기업 공개만, 기업 공개 제외
+				PostBooleanExpression.IDEA_TITLE_CONTAINS.get(keyword),              // 3. 검색어 필터
+				PostBooleanExpression.IDEA_CATEGORY_EQ.get(category),                // 4. 카테고리 필터
+				PostBooleanExpression.IDEA_ONLY_COMPANY.get(onlyCompany)             // 5. 기업 공개만, 기업 공개 제외
 			)
 			.reduce(BooleanExpression::and)
 			.orElse(null);
 
 		// 정렬 조건 (기본 값은 최신순)
-		OrderSpecifier<?> order = sortType != null ? sortType.getOrder() : SortType.NEWEST.getOrder();
+		OrderSpecifier<?> order = sortType != null ? sortType.getOrder() : SortType.IDEA_NEWEST.getOrder();
 
 		// 조회 결과
 		List<Tuple> queryResult = queryFactory
@@ -88,7 +85,7 @@ public class IdeaMarketCustomRepositoryImpl implements IdeaMarketCustomRepositor
 
 		// 검색 조건
 		BooleanExpression where = Stream.of(
-				PostBooleanExpression.EXCLUDE_PRIVATE.get(null),                // 1. 비공개 제외
+				PostBooleanExpression.IDEA_EXCLUDE_PRIVATE.get(null),                // 1. 비공개 제외
 				PostBooleanExpression.IDEA_MARKET_TYPE_EQ.get(ideaMarketType)  // 2. 아이디어 필터링 (IDEA_SOLUTION, MARKET_PLACE)
 			)
 			.reduce(BooleanExpression::and)

--- a/src/main/java/com/brainpix/post/service/CollaborationHubService.java
+++ b/src/main/java/com/brainpix/post/service/CollaborationHubService.java
@@ -1,0 +1,29 @@
+package com.brainpix.post.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.brainpix.post.converter.GetCollaborationHubListDtoConverter;
+import com.brainpix.post.dto.GetCollaborationHubListDto;
+import com.brainpix.post.repository.CollaborationHubRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CollaborationHubService {
+
+	private final CollaborationHubRepository collaborationHubRepository;
+
+	@Transactional(readOnly = true)
+	public GetCollaborationHubListDto.Response getCollaborationHubList(GetCollaborationHubListDto.Parameter parameter) {
+
+		// 협업 게시글-저장수 쌍으로 반환된 결과
+		Page<Object[]> result = collaborationHubRepository.findCollaborationListWithSaveCount(
+			parameter.getKeyword(), parameter.getCategory(), parameter.getOnlyCompany(), parameter.getSortType(),
+			parameter.getPageable());
+
+		return GetCollaborationHubListDtoConverter.toResponse(result);
+	}
+}

--- a/src/main/java/com/brainpix/post/service/CollaborationHubService.java
+++ b/src/main/java/com/brainpix/post/service/CollaborationHubService.java
@@ -1,12 +1,24 @@
 package com.brainpix.post.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.brainpix.api.code.error.CommonErrorCode;
+import com.brainpix.api.exception.BrainPixException;
+import com.brainpix.joining.entity.purchasing.CollectionGathering;
+import com.brainpix.joining.repository.CollectionGatheringRepository;
+import com.brainpix.post.converter.GetCollaborationHubDetailDtoConverter;
 import com.brainpix.post.converter.GetCollaborationHubListDtoConverter;
+import com.brainpix.post.dto.GetCollaborationHubDetailDto;
 import com.brainpix.post.dto.GetCollaborationHubListDto;
+import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
 import com.brainpix.post.repository.CollaborationHubRepository;
+import com.brainpix.post.repository.IdeaMarketRepository;
+import com.brainpix.post.repository.SavedPostRepository;
+import com.brainpix.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +27,9 @@ import lombok.RequiredArgsConstructor;
 public class CollaborationHubService {
 
 	private final CollaborationHubRepository collaborationHubRepository;
+	private final SavedPostRepository savedPostRepository;
+	private final IdeaMarketRepository ideaMarketRepository;
+	private final CollectionGatheringRepository collectionGatheringRepository;
 
 	@Transactional(readOnly = true)
 	public GetCollaborationHubListDto.Response getCollaborationHubList(GetCollaborationHubListDto.Parameter parameter) {
@@ -25,5 +40,34 @@ public class CollaborationHubService {
 			parameter.getPageable());
 
 		return GetCollaborationHubListDtoConverter.toResponse(result);
+	}
+
+	@Transactional(readOnly = true)
+	public GetCollaborationHubDetailDto.Response getCollaborationHubDetail(
+		GetCollaborationHubDetailDto.Parameter parameter) {
+
+		// 협업 게시글 조회
+		CollaborationHub collaborationHub = collaborationHubRepository.findById(parameter.getCollaborationId())
+			.orElseThrow(() -> new BrainPixException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		// 작성자 조회
+		User writer = collaborationHub.getWriter();
+		System.out.println(writer.getId());
+
+		// 아이디어의 저장 횟수
+		Long saveCount = savedPostRepository.countByPostId(collaborationHub.getId());
+
+		// 작성자의 아이디어 개수
+		Long totalIdeas = ideaMarketRepository.countByWriterId(writer.getId());
+
+		// 작성자의 협업 횟수
+		Long totalCollaborations = collectionGatheringRepository.countByJoinerIdAndAccepted(writer.getId(), true);
+
+		// 개최 인원
+		List<CollectionGathering> collectionGatherings = collectionGatheringRepository.findByCollaborationHubId(
+			collaborationHub.getId());
+
+		return GetCollaborationHubDetailDtoConverter.toResponse(collaborationHub, collectionGatherings, writer,
+			saveCount, totalIdeas, totalCollaborations);
 	}
 }

--- a/src/main/java/com/brainpix/post/service/CollaborationHubService.java
+++ b/src/main/java/com/brainpix/post/service/CollaborationHubService.java
@@ -62,7 +62,7 @@ public class CollaborationHubService {
 
 		// 작성자의 협업 횟수
 		Long totalCollaborations = collectionGatheringRepository.countByJoinerIdAndAccepted(writer.getId(), true);
-
+		
 		// 개최 인원
 		List<CollectionGathering> collectionGatherings = collectionGatheringRepository.findByCollaborationHubId(
 			collaborationHub.getId());


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #35 

## ✨ PR 세부 내용

1. 아이디어 조회와 비슷한 과정으로 QueyDSL을 이용하여 전체 조회와 상세 조회를 구현하였습니다.

<br>

2. CollectionGathering에 새로 추가된 Boolean initialGathering 을 고려하여 
협업 광장의 id로 개최에 해당하는 CollectionGathering 엔티티만을 조회할 수 있도록 하였습니다.
```java
// 개최 인원 등록 정보 조회
@Query("SELECT cg FROM CollectionGathering cg " +
"JOIN FETCH cg.collaborationRecruitment cr " +
"WHERE cr.parentCollaborationHub.id = :collaborationHubId " +
"AND cg.initialGathering = true")
List<CollectionGathering> findByCollaborationHubId(@Param("collaborationHubId") Long collaborationHubId);
```

<br>

3. 이후 컨버터에서 모집 단위를 만들 때, 개최에 해당하는 모집 단위는 필터링하도록 로직을 짰습니다.

```java
// 모집 단위 (개최에 속하지 않는 모집 단위만 필터링)
List<GetCollaborationHubDetailDto.Recruitment> recruitments = collaborationHub.getCollaborations().stream()
	.filter(recruitment ->
		collectionGathering.stream()
			.noneMatch(gathering -> gathering.getCollaborationRecruitment().equals(recruitment))
	)
	.map(GetCollaborationHubDetailDtoConverter::toRecruitment)
	.toList();

// 개최 인원 정보 파싱
List<GetCollaborationHubDetailDto.OpenMember> openMembers = collectionGathering.stream()
	.map(GetCollaborationHubDetailDtoConverter::toOpenMember)
	.toList();
```

<br>

4. 개최 인원의 포트폴리오 공개 여부는 일단 확인할 방법이 없는 것 같아. 컨버터에서 주석 처리해두었습니다. 추후 등록 api가 완성되면 수정하도록 하겠습니다.
![image](https://github.com/user-attachments/assets/2ebb7ce9-ee05-49eb-b936-e038306c1a6d)
