### PR TITLE
[FEAT] 지원현황 API 구현(#59)

### DIFF
--- a/src/main/java/com/brainpix/api/code/error/CollectionErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/CollectionErrorCode.java
@@ -1,0 +1,19 @@
+package com.brainpix.api.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CollectionErrorCode implements ErrorCode {
+	COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "COLLECTION404", "지원 내역이 존재하지 않습니다."),
+	NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COLLECTION403", "본인이 지원한 항목이 아닙니다."),
+	INVALID_STATUS(HttpStatus.BAD_REQUEST, "COLLECTION400", "거절 상태가 아닌 항목은 삭제할 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+}

--- a/src/main/java/com/brainpix/api/code/error/PurchasingErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/PurchasingErrorCode.java
@@ -1,0 +1,19 @@
+package com.brainpix.api.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PurchasingErrorCode implements ErrorCode {
+	COLLECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PURCHASING404", "지원 내역이 존재하지 않습니다."),
+	NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PURCHASING403", "본인이 지원한 항목이 아닙니다."),
+	INVALID_STATUS(HttpStatus.BAD_REQUEST, "PURCHASING400", "거절 상태가 아닌 항목은 삭제할 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+}

--- a/src/main/java/com/brainpix/joining/controller/SupportCollaborationController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportCollaborationController.java
@@ -1,7 +1,7 @@
 package com.brainpix.joining.controller;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,29 +24,21 @@ public class SupportCollaborationController {
 
 	private final SupportCollaborationService supportCollaborationService;
 
-	/**
-	 * [GET] 거절 목록
-	 */
 	@GetMapping("/rejected")
-	public ResponseEntity<ApiResponse<List<RejectedCollaborationDto>>> getRejectedList(
-		@RequestParam Long userId) {
+	public ResponseEntity<ApiResponse<Page<RejectedCollaborationDto>>> getRejectedList(
+		@RequestParam Long userId,
+		Pageable pageable) {
 
-		List<RejectedCollaborationDto> dtos =
-			supportCollaborationService.getRejectedList(userId);
-
+		Page<RejectedCollaborationDto> dtos = supportCollaborationService.getRejectedList(userId, pageable);
 		return ResponseEntity.ok(ApiResponse.success(dtos));
 	}
 
-	/**
-	 * [GET] 수락 목록
-	 */
 	@GetMapping("/accepted")
-	public ResponseEntity<ApiResponse<List<AcceptedCollaborationDto>>> getAcceptedList(
-		@RequestParam Long userId) {
+	public ResponseEntity<ApiResponse<Page<AcceptedCollaborationDto>>> getAcceptedList(
+		@RequestParam Long userId,
+		Pageable pageable) {
 
-		List<AcceptedCollaborationDto> dtos =
-			supportCollaborationService.getAcceptedList(userId);
-
+		Page<AcceptedCollaborationDto> dtos = supportCollaborationService.getAcceptedList(userId, pageable);
 		return ResponseEntity.ok(ApiResponse.success(dtos));
 	}
 

--- a/src/main/java/com/brainpix/joining/controller/SupportCollaborationController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportCollaborationController.java
@@ -1,0 +1,64 @@
+package com.brainpix.joining.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.brainpix.api.ApiResponse;
+import com.brainpix.joining.dto.AcceptedCollaborationDto;
+import com.brainpix.joining.dto.RejectedCollaborationDto;
+import com.brainpix.joining.service.SupportCollaborationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/supports/collaborations")
+@RequiredArgsConstructor
+public class SupportCollaborationController {
+
+	private final SupportCollaborationService supportCollaborationService;
+
+	/**
+	 * [GET] 거절 목록
+	 */
+	@GetMapping("/rejected")
+	public ResponseEntity<ApiResponse<List<RejectedCollaborationDto>>> getRejectedList(
+		@RequestParam Long userId) {
+
+		List<RejectedCollaborationDto> dtos =
+			supportCollaborationService.getRejectedList(userId);
+
+		return ResponseEntity.ok(ApiResponse.success(dtos));
+	}
+
+	/**
+	 * [GET] 수락 목록
+	 */
+	@GetMapping("/accepted")
+	public ResponseEntity<ApiResponse<List<AcceptedCollaborationDto>>> getAcceptedList(
+		@RequestParam Long userId) {
+
+		List<AcceptedCollaborationDto> dtos =
+			supportCollaborationService.getAcceptedList(userId);
+
+		return ResponseEntity.ok(ApiResponse.success(dtos));
+	}
+
+	/**
+	 * [DELETE] 거절 항목 삭제
+	 */
+	@DeleteMapping("/{collectionGatheringId}")
+	public ResponseEntity<ApiResponse<Void>> deleteRejected(
+		@PathVariable Long collectionGatheringId,
+		@RequestParam Long userId) {
+
+		supportCollaborationService.deleteRejected(userId, collectionGatheringId);
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+}

--- a/src/main/java/com/brainpix/joining/controller/SupportIdeaMarketController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportIdeaMarketController.java
@@ -1,7 +1,6 @@
 package com.brainpix.joining.controller;
 
-import java.util.List;
-
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.brainpix.api.ApiResponse;
+import com.brainpix.api.CommonPageResponse;
 import com.brainpix.joining.dto.IdeaMarketPurchaseDto;
 import com.brainpix.joining.service.SupportIdeaMarketService;
 
@@ -22,10 +22,12 @@ public class SupportIdeaMarketController {
 	private final SupportIdeaMarketService supportIdeaMarketService;
 
 	@GetMapping("/purchases")
-	public ResponseEntity<ApiResponse<List<IdeaMarketPurchaseDto>>> getPurchases(
-		@RequestParam Long userId
+	public ResponseEntity<ApiResponse<CommonPageResponse<IdeaMarketPurchaseDto>>> getPurchases(
+		@RequestParam Long userId,
+		Pageable pageable
 	) {
-		List<IdeaMarketPurchaseDto> dtos = supportIdeaMarketService.getMyPurchases(userId);
-		return ResponseEntity.ok(ApiResponse.success(dtos));
+		CommonPageResponse<IdeaMarketPurchaseDto> response = supportIdeaMarketService.getMyPurchases(userId, pageable);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
+
 }

--- a/src/main/java/com/brainpix/joining/controller/SupportIdeaMarketController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportIdeaMarketController.java
@@ -1,0 +1,31 @@
+package com.brainpix.joining.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.brainpix.api.ApiResponse;
+import com.brainpix.joining.dto.IdeaMarketPurchaseDto;
+import com.brainpix.joining.service.SupportIdeaMarketService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/supports/idea-market")
+@RequiredArgsConstructor
+public class SupportIdeaMarketController {
+
+	private final SupportIdeaMarketService supportIdeaMarketService;
+
+	@GetMapping("/purchases")
+	public ResponseEntity<ApiResponse<List<IdeaMarketPurchaseDto>>> getPurchases(
+		@RequestParam Long userId
+	) {
+		List<IdeaMarketPurchaseDto> dtos = supportIdeaMarketService.getMyPurchases(userId);
+		return ResponseEntity.ok(ApiResponse.success(dtos));
+	}
+}

--- a/src/main/java/com/brainpix/joining/controller/SupportRequestTaskController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportRequestTaskController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.brainpix.api.ApiResponse;
 import com.brainpix.joining.dto.AcceptedRequestTaskPurchasingDto;
 import com.brainpix.joining.dto.RejectedRequestTaskPurchasingDto;
 import com.brainpix.joining.service.SupportRequestTaskService;
@@ -24,26 +25,29 @@ public class SupportRequestTaskController {
 	private final SupportRequestTaskService supportRequestTaskService;
 
 	@GetMapping("/rejected")
-	public ResponseEntity<List<RejectedRequestTaskPurchasingDto>> getRejectedList(
+	public ResponseEntity<ApiResponse<List<RejectedRequestTaskPurchasingDto>>> getRejectedList(
 		@RequestParam Long userId) {
 		List<RejectedRequestTaskPurchasingDto> dtos =
 			supportRequestTaskService.getRejectedList(userId);
-		return ResponseEntity.ok(dtos);
+		return ResponseEntity
+			.ok(ApiResponse.success(dtos));
 	}
 
 	@GetMapping("/accepted")
-	public ResponseEntity<List<AcceptedRequestTaskPurchasingDto>> getAcceptedList(
+	public ResponseEntity<ApiResponse<List<AcceptedRequestTaskPurchasingDto>>> getAcceptedList(
 		@RequestParam Long userId) {
 		List<AcceptedRequestTaskPurchasingDto> dtos =
 			supportRequestTaskService.getAcceptedList(userId);
-		return ResponseEntity.ok(dtos);
+		return ResponseEntity
+			.ok(ApiResponse.success(dtos));
 	}
 
 	@DeleteMapping("/{purchasingId}")
-	public ResponseEntity<Void> deleteRejectedPurchasing(
+	public ResponseEntity<ApiResponse<Void>> deleteRejectedPurchasing(
 		@PathVariable Long purchasingId,
 		@RequestParam Long userId) {
 		supportRequestTaskService.deleteRejectedPurchasing(userId, purchasingId);
-		return ResponseEntity.noContent().build();
+		return ResponseEntity
+			.ok(ApiResponse.successWithNoData());
 	}
 }

--- a/src/main/java/com/brainpix/joining/controller/SupportRequestTaskController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportRequestTaskController.java
@@ -1,0 +1,49 @@
+package com.brainpix.joining.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.brainpix.joining.dto.AcceptedRequestTaskPurchasingDto;
+import com.brainpix.joining.dto.RejectedRequestTaskPurchasingDto;
+import com.brainpix.joining.service.SupportRequestTaskService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/supports/request-tasks")
+@RequiredArgsConstructor
+public class SupportRequestTaskController {
+
+	private final SupportRequestTaskService supportRequestTaskService;
+
+	@GetMapping("/rejected")
+	public ResponseEntity<List<RejectedRequestTaskPurchasingDto>> getRejectedList(
+		@RequestParam Long userId) {
+		List<RejectedRequestTaskPurchasingDto> dtos =
+			supportRequestTaskService.getRejectedList(userId);
+		return ResponseEntity.ok(dtos);
+	}
+
+	@GetMapping("/accepted")
+	public ResponseEntity<List<AcceptedRequestTaskPurchasingDto>> getAcceptedList(
+		@RequestParam Long userId) {
+		List<AcceptedRequestTaskPurchasingDto> dtos =
+			supportRequestTaskService.getAcceptedList(userId);
+		return ResponseEntity.ok(dtos);
+	}
+
+	@DeleteMapping("/{purchasingId}")
+	public ResponseEntity<Void> deleteRejectedPurchasing(
+		@PathVariable Long purchasingId,
+		@RequestParam Long userId) {
+		supportRequestTaskService.deleteRejectedPurchasing(userId, purchasingId);
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/com/brainpix/joining/controller/SupportRequestTaskController.java
+++ b/src/main/java/com/brainpix/joining/controller/SupportRequestTaskController.java
@@ -1,7 +1,6 @@
 package com.brainpix.joining.controller;
 
-import java.util.List;
-
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.brainpix.api.ApiResponse;
+import com.brainpix.api.CommonPageResponse;
 import com.brainpix.joining.dto.AcceptedRequestTaskPurchasingDto;
 import com.brainpix.joining.dto.RejectedRequestTaskPurchasingDto;
 import com.brainpix.joining.service.SupportRequestTaskService;
@@ -25,21 +25,23 @@ public class SupportRequestTaskController {
 	private final SupportRequestTaskService supportRequestTaskService;
 
 	@GetMapping("/rejected")
-	public ResponseEntity<ApiResponse<List<RejectedRequestTaskPurchasingDto>>> getRejectedList(
-		@RequestParam Long userId) {
-		List<RejectedRequestTaskPurchasingDto> dtos =
-			supportRequestTaskService.getRejectedList(userId);
-		return ResponseEntity
-			.ok(ApiResponse.success(dtos));
+	public ResponseEntity<ApiResponse<CommonPageResponse<RejectedRequestTaskPurchasingDto>>> getRejectedList(
+		@RequestParam Long userId,
+		Pageable pageable
+	) {
+		CommonPageResponse<RejectedRequestTaskPurchasingDto> response =
+			supportRequestTaskService.getRejectedList(userId, pageable);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	@GetMapping("/accepted")
-	public ResponseEntity<ApiResponse<List<AcceptedRequestTaskPurchasingDto>>> getAcceptedList(
-		@RequestParam Long userId) {
-		List<AcceptedRequestTaskPurchasingDto> dtos =
-			supportRequestTaskService.getAcceptedList(userId);
-		return ResponseEntity
-			.ok(ApiResponse.success(dtos));
+	public ResponseEntity<ApiResponse<CommonPageResponse<AcceptedRequestTaskPurchasingDto>>> getAcceptedList(
+		@RequestParam Long userId,
+		Pageable pageable
+	) {
+		CommonPageResponse<AcceptedRequestTaskPurchasingDto> response =
+			supportRequestTaskService.getAcceptedList(userId, pageable);
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
 	@DeleteMapping("/{purchasingId}")

--- a/src/main/java/com/brainpix/joining/converter/CollectionGatheringConverter.java
+++ b/src/main/java/com/brainpix/joining/converter/CollectionGatheringConverter.java
@@ -1,0 +1,105 @@
+package com.brainpix.joining.converter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.brainpix.joining.dto.AcceptedCollaborationDto;
+import com.brainpix.joining.dto.RejectedCollaborationDto;
+import com.brainpix.joining.dto.TeamMemberInfoDto;
+import com.brainpix.joining.entity.purchasing.CollectionGathering;
+import com.brainpix.joining.entity.quantity.Gathering;
+import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
+import com.brainpix.post.entity.collaboration_hub.CollaborationRecruitment;
+import com.brainpix.user.entity.Individual;
+import com.brainpix.user.entity.User;
+
+@Component
+public class CollectionGatheringConverter {
+
+	/**
+	 * [A] 거절된 협업 목록 DTO
+	 */
+	public RejectedCollaborationDto toRejectedDto(CollectionGathering cg) {
+		CollaborationRecruitment recruitment = cg.getCollaborationRecruitment();
+		CollaborationHub hub = recruitment.getParentCollaborationHub();
+
+		return RejectedCollaborationDto.builder()
+			.collectionGatheringId(cg.getId())
+			.firstImage(hub.getFirstImage())                // Post#getFirstImage()
+			.postCreatedAt(hub.getCreatedAt())            // BaseTimeEntity
+			.postTitle(hub.getTitle())
+			.postCategory("협업 광장 > " + hub.getSpecialization())
+			.domain(recruitment.getDomain())
+			.build();
+	}
+
+	/**
+	 * [B] 수락된 협업 상세 DTO
+	 *  - 본인이 지원한 CollectionGathering + 게시글 정보 + 팀원 정보
+	 */
+	public AcceptedCollaborationDto toAcceptedDto(CollectionGathering cg,
+		List<TeamMemberInfoDto> teamInfoList) {
+		CollaborationRecruitment recruitment = cg.getCollaborationRecruitment();
+		CollaborationHub hub = recruitment.getParentCollaborationHub();
+
+		// 작성자 정보
+		User writer = hub.getWriter();
+		String writerName = writer.getName();
+		String writerType = (writer instanceof Individual) ? "개인" : "회사";
+
+		return AcceptedCollaborationDto.builder()
+			.collectionGatheringId(cg.getId())
+			.firstImage(hub.getFirstImage())
+			.postCreatedAt(hub.getCreatedAt())
+			.postTitle(hub.getTitle())
+			.postCategory("협업 광장 > " + hub.getSpecialization())
+			.domain(recruitment.getDomain())
+			.writerName(writerName)
+			.writerType(writerType)
+			.teamInfoList(teamInfoList)
+			.build();
+	}
+
+	/**
+	 * [C] 팀원 정보(TeamMemberInfoDto) 생성
+	 *   - 게시글의 모든 CollaborationRecruitment 목록을 순회하며
+	 *   - 각 도메인별 Gathering(totalQuantity)와 (accepted= true or initialGathering= true) 참가자들
+	 */
+	public List<TeamMemberInfoDto> createTeamInfoList(CollaborationHub hub) {
+		List<CollaborationRecruitment> recruitments = hub.getCollaborations();
+
+		return recruitments.stream()
+			.map(this::toTeamMemberInfoDto)
+			.collect(Collectors.toList());
+	}
+
+	private TeamMemberInfoDto toTeamMemberInfoDto(CollaborationRecruitment recruitment) {
+
+		Gathering gathering = recruitment.getGathering();
+		Long total = (gathering != null) ? gathering.getTotalQuantity() : 0L;
+		Long occupied = (gathering != null) ? gathering.getOccupiedQuantity() : 0L;
+
+		List<CollectionGathering> joined =
+			findAcceptedOrInitial(recruitment.getCollectionGatherings());
+
+		List<String> joinerIds = joined.stream()
+			.map(cg -> cg.getJoiner().getName())
+			.collect(Collectors.toList());
+
+		return TeamMemberInfoDto.builder()
+			.domain(recruitment.getDomain())
+			.occupied(occupied)
+			.total(total)
+			.joinerIds(joinerIds)
+			.build();
+	}
+
+	private List<CollectionGathering> findAcceptedOrInitial(List<CollectionGathering> cgs) {
+		return cgs.stream()
+			.filter(cg -> Boolean.TRUE.equals(cg.getAccepted())
+				|| Boolean.TRUE.equals(cg.getInitialGathering()))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/brainpix/joining/converter/IdeaMarketPurchasingConverter.java
+++ b/src/main/java/com/brainpix/joining/converter/IdeaMarketPurchasingConverter.java
@@ -1,0 +1,59 @@
+package com.brainpix.joining.converter;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+import com.brainpix.joining.dto.IdeaMarketPurchaseDto;
+import com.brainpix.joining.entity.purchasing.IdeaMarketPurchasing;
+import com.brainpix.joining.entity.quantity.Price;
+import com.brainpix.post.entity.idea_market.IdeaMarket;
+import com.brainpix.post.entity.idea_market.IdeaMarketType;
+import com.brainpix.user.entity.Individual;
+import com.brainpix.user.entity.User;
+
+@Component
+public class IdeaMarketPurchasingConverter {
+
+	public IdeaMarketPurchaseDto toPurchaseDto(IdeaMarketPurchasing purchasing) {
+		Long purchasingId = purchasing.getId();
+		LocalDateTime purchasedAt = purchasing.getCreatedAt();
+
+		// 게시글
+		IdeaMarket ideaMarket = purchasing.getIdeaMarket();
+		String category = "아이디어마켓 > " + ideaMarket.getSpecialization();
+		String title = ideaMarket.getTitle();
+
+		// 작성자
+		User writer = ideaMarket.getWriter();
+		String writerName = writer.getName();
+		String writerType = (writer instanceof Individual) ? "개인" : "회사";
+
+		// 아이디어마켓 타입
+		IdeaMarketType type = ideaMarket.getIdeaMarketType();
+
+		// 수량 결정 (IDEA_SOLUTION → 1, MARKET_PLACE → price.totalQuantity)
+		Price priceEntity = ideaMarket.getPrice();
+		Long quantity = (type == IdeaMarketType.IDEA_SOLUTION)
+			? 1L
+			: priceEntity.getTotalQuantity();
+
+		// 금액 계산
+		long basePrice = priceEntity.getPrice() * quantity;
+		long fee = (long)(basePrice * 0.01); // 1% 예시
+		long finalPrice = basePrice + fee;
+
+		return IdeaMarketPurchaseDto.builder()
+			.purchasingId(purchasingId)
+			.purchasedAt(purchasedAt)
+			.category(category)
+			.title(title)
+			.writerName(writerName)
+			.writerType(writerType)
+			.quantity(quantity)
+			.fee(fee)
+			.finalPrice(finalPrice)
+			.build();
+	}
+}
+

--- a/src/main/java/com/brainpix/joining/converter/RequestTaskPurchasingConverter.java
+++ b/src/main/java/com/brainpix/joining/converter/RequestTaskPurchasingConverter.java
@@ -1,0 +1,57 @@
+package com.brainpix.joining.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.brainpix.joining.dto.AcceptedRequestTaskPurchasingDto;
+import com.brainpix.joining.dto.RejectedRequestTaskPurchasingDto;
+import com.brainpix.joining.entity.purchasing.RequestTaskPurchasing;
+import com.brainpix.post.entity.request_task.RequestTask;
+import com.brainpix.post.entity.request_task.RequestTaskRecruitment;
+import com.brainpix.user.entity.Individual;
+import com.brainpix.user.entity.User;
+
+@Component
+public class RequestTaskPurchasingConverter {
+
+	/**
+	 * 거절된 지원 목록용 DTO 변환
+	 */
+	public RejectedRequestTaskPurchasingDto toRejectedDto(RequestTaskPurchasing p) {
+
+		RequestTaskRecruitment recruitment = p.getRequestTaskRecruitment();
+	
+		RequestTask requestTask = recruitment.getRequestTask();
+
+		return RejectedRequestTaskPurchasingDto.builder()
+			.purchasingId(p.getId())
+			.firstImage(requestTask.getFirstImage())
+			.postCreatedAt(requestTask.getCreatedAt())
+			.postTitle(requestTask.getTitle())
+			.postCategory("요청 과제 > " + requestTask.getSpecialization())
+			.domain(recruitment.getDomain())
+			.build();
+	}
+
+	/**
+	 * 수락된 지원 목록용 DTO 변환
+	 */
+	public AcceptedRequestTaskPurchasingDto toAcceptedDto(RequestTaskPurchasing p) {
+		RequestTaskRecruitment recruitment = p.getRequestTaskRecruitment();
+		RequestTask requestTask = recruitment.getRequestTask();
+
+		User writer = requestTask.getWriter();
+		String writerName = writer.getName();
+		String writerType = (writer instanceof Individual) ? "개인" : "회사";
+
+		return AcceptedRequestTaskPurchasingDto.builder()
+			.purchasingId(p.getId())
+			.firstImage(requestTask.getFirstImage())
+			.postCreatedAt(requestTask.getCreatedAt())
+			.postTitle(requestTask.getTitle())
+			.postCategory("요청 과제 > " + requestTask.getSpecialization())
+			.domain(recruitment.getDomain())
+			.writerName(writerName)
+			.writerType(writerType)
+			.build();
+	}
+}

--- a/src/main/java/com/brainpix/joining/dto/AcceptedCollaborationDto.java
+++ b/src/main/java/com/brainpix/joining/dto/AcceptedCollaborationDto.java
@@ -1,0 +1,30 @@
+package com.brainpix.joining.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AcceptedCollaborationDto {
+
+	private Long collectionGatheringId;   // CollectionGathering PK
+	private String firstImage;            // 게시글 대표 이미지
+	private LocalDateTime postCreatedAt;  // 게시글 작성일
+	private String postTitle;             // 게시글 제목
+	private String postCategory;          // "협업 광장 > 디자인"
+	private String domain;                // 내가 지원한 파트 (ex: "PM")
+
+	// 게시글 관리자
+	private String writerName;            // 작성자 이름 (ex: "SEO YEON")
+	private String writerType;            // "개인" or "회사"
+
+	// 팀원 정보 (모든 도메인에 대한 현재인원/총인원 + 멤버)
+	private List<TeamMemberInfoDto> teamInfoList;
+}

--- a/src/main/java/com/brainpix/joining/dto/AcceptedRequestTaskPurchasingDto.java
+++ b/src/main/java/com/brainpix/joining/dto/AcceptedRequestTaskPurchasingDto.java
@@ -1,0 +1,25 @@
+package com.brainpix.joining.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AcceptedRequestTaskPurchasingDto {
+	private Long purchasingId;            // RequestTaskPurchasing PK
+	private String firstImage;            // 게시글 대표 이미지
+	private LocalDateTime postCreatedAt;  // 게시글 작성일
+	private String postTitle;             // 게시글 제목
+	private String postCategory;          // "요청 과제 > 디자인"
+	private String domain;                // 지원 파트
+
+	// 게시물 작성자 정보 (이름 + 개인/회사)
+	private String writerName;
+	private String writerType;            // "개인" or "회사"
+}

--- a/src/main/java/com/brainpix/joining/dto/IdeaMarketPurchaseDto.java
+++ b/src/main/java/com/brainpix/joining/dto/IdeaMarketPurchaseDto.java
@@ -1,0 +1,32 @@
+package com.brainpix.joining.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IdeaMarketPurchaseDto {
+	private Long purchasingId;
+	private LocalDateTime purchasedAt;
+
+	// 게시글 정보
+	private String category;      // "아이디어마켓 > IT_TECH"
+	private String title;
+	private String writerName;
+	private String writerType;    // "개인"/"회사"
+
+	// 수량
+	private Long quantity;
+
+	// 결제금액 계산
+	private Long fee;            // 수수료
+	private Long finalPrice;     // (price × quantity) + fee
+	
+}
+

--- a/src/main/java/com/brainpix/joining/dto/RejectedCollaborationDto.java
+++ b/src/main/java/com/brainpix/joining/dto/RejectedCollaborationDto.java
@@ -1,0 +1,21 @@
+package com.brainpix.joining.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RejectedCollaborationDto {
+	private Long collectionGatheringId;   // CollectionGathering PK
+	private String firstImage;            // 게시글 대표 이미지
+	private LocalDateTime postCreatedAt;  // 게시글 작성일
+	private String postTitle;             // 게시글 제목
+	private String postCategory;          // "협업 광장 > 디자인" 등
+	private String domain;                // 지원한 파트
+}

--- a/src/main/java/com/brainpix/joining/dto/RejectedRequestTaskPurchasingDto.java
+++ b/src/main/java/com/brainpix/joining/dto/RejectedRequestTaskPurchasingDto.java
@@ -1,0 +1,21 @@
+package com.brainpix.joining.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RejectedRequestTaskPurchasingDto {
+	private Long purchasingId;            // RequestTaskPurchasing PK
+	private String firstImage;            // 게시글 대표 이미지
+	private LocalDateTime postCreatedAt;  // 게시글 작성일 (BaseTimeEntity)
+	private String postTitle;             // 게시글 제목
+	private String postCategory;          // 예: "요청 과제 > 디자인"
+	private String domain;                // 지원 파트 (ex: "디자이너")
+}

--- a/src/main/java/com/brainpix/joining/dto/TeamMemberInfoDto.java
+++ b/src/main/java/com/brainpix/joining/dto/TeamMemberInfoDto.java
@@ -1,0 +1,19 @@
+package com.brainpix.joining.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamMemberInfoDto {
+	private String domain;       // 역할 (예: "디자이너")
+	private Long occupied;       // 현재 인원수
+	private Long total;          // 모집 정원
+	private List<String> joinerIds; // 수락/초기멤버들의 아이디 목록
+}

--- a/src/main/java/com/brainpix/joining/entity/purchasing/CollectionGathering.java
+++ b/src/main/java/com/brainpix/joining/entity/purchasing/CollectionGathering.java
@@ -1,5 +1,7 @@
 package com.brainpix.joining.entity.purchasing;
 
+import com.brainpix.api.code.error.CollectionErrorCode;
+import com.brainpix.api.exception.BrainPixException;
 import com.brainpix.jpa.BaseTimeEntity;
 import com.brainpix.post.entity.collaboration_hub.CollaborationRecruitment;
 import com.brainpix.user.entity.User;
@@ -36,5 +38,17 @@ public class CollectionGathering extends BaseTimeEntity {
 		this.accepted = accepted;
 		this.initialGathering = initialGathering;
 		this.collaborationRecruitment = collaborationRecruitment;
+	}
+
+	public void validateJoiner(User user) {
+		if (!this.joiner.equals(user)) {
+			throw new BrainPixException(CollectionErrorCode.NOT_AUTHORIZED);
+		}
+	}
+
+	public void validateRejectedStatus() {
+		if (Boolean.TRUE.equals(this.accepted)) {
+			throw new BrainPixException(CollectionErrorCode.INVALID_STATUS);
+		}
 	}
 }

--- a/src/main/java/com/brainpix/joining/entity/purchasing/RequestTaskPurchasing.java
+++ b/src/main/java/com/brainpix/joining/entity/purchasing/RequestTaskPurchasing.java
@@ -1,5 +1,7 @@
 package com.brainpix.joining.entity.purchasing;
 
+import com.brainpix.api.code.error.PurchasingErrorCode;
+import com.brainpix.api.exception.BrainPixException;
 import com.brainpix.joining.entity.quantity.PaymentDuration;
 import com.brainpix.jpa.BaseTimeEntity;
 import com.brainpix.post.entity.request_task.RequestTaskRecruitment;
@@ -40,5 +42,17 @@ public class RequestTaskPurchasing extends BaseTimeEntity {
 		this.paymentDuration = paymentDuration;
 		this.accepted = accepted;
 		this.requestTaskRecruitment = requestTaskRecruitment;
+	}
+
+	public void validateBuyer(User user) {
+		if (!this.buyer.equals(user)) {
+			throw new BrainPixException(PurchasingErrorCode.NOT_AUTHORIZED);
+		}
+	}
+
+	public void validateRejectedStatus() {
+		if (Boolean.TRUE.equals(this.accepted)) {
+			throw new BrainPixException(PurchasingErrorCode.INVALID_STATUS);
+		}
 	}
 }

--- a/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
@@ -1,7 +1,7 @@
 package com.brainpix.joining.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.brainpix.joining.entity.purchasing.CollectionGathering;
@@ -12,7 +12,7 @@ public interface CollectionGatheringRepository extends JpaRepository<CollectionG
 	// 협업 횟수 조회 (승낙된 협업)
 	Long countByJoinerIdAndAccepted(Long joinerId, Boolean accepted);
 
-	List<CollectionGathering> findByJoinerAndAcceptedIsFalse(User joiner);
+	Page<CollectionGathering> findByJoinerAndAcceptedIsFalse(User joiner, Pageable pageable);
 
-	List<CollectionGathering> findByJoinerAndAcceptedIsTrue(User joiner);
+	Page<CollectionGathering> findByJoinerAndAcceptedIsTrue(User joiner, Pageable pageable);
 }

--- a/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/CollectionGatheringRepository.java
@@ -1,11 +1,18 @@
 package com.brainpix.joining.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.brainpix.joining.entity.purchasing.CollectionGathering;
+import com.brainpix.user.entity.User;
 
 public interface CollectionGatheringRepository extends JpaRepository<CollectionGathering, Long> {
 
 	// 협업 횟수 조회 (승낙된 협업)
 	Long countByJoinerIdAndAccepted(Long joinerId, Boolean accepted);
+
+	List<CollectionGathering> findByJoinerAndAcceptedIsFalse(User joiner);
+
+	List<CollectionGathering> findByJoinerAndAcceptedIsTrue(User joiner);
 }

--- a/src/main/java/com/brainpix/joining/repository/IdeaMarketPurchasingRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/IdeaMarketPurchasingRepository.java
@@ -1,7 +1,7 @@
 package com.brainpix.joining.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,5 +11,6 @@ import com.brainpix.user.entity.User;
 @Repository
 public interface IdeaMarketPurchasingRepository
 	extends JpaRepository<IdeaMarketPurchasing, Long> {
-	List<IdeaMarketPurchasing> findByBuyer(User buyer);
+	Page<IdeaMarketPurchasing> findByBuyer(User buyer, Pageable pageable);
+
 }

--- a/src/main/java/com/brainpix/joining/repository/IdeaMarketPurchasingRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/IdeaMarketPurchasingRepository.java
@@ -1,0 +1,15 @@
+package com.brainpix.joining.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.brainpix.joining.entity.purchasing.IdeaMarketPurchasing;
+import com.brainpix.user.entity.User;
+
+@Repository
+public interface IdeaMarketPurchasingRepository
+	extends JpaRepository<IdeaMarketPurchasing, Long> {
+	List<IdeaMarketPurchasing> findByBuyer(User buyer);
+}

--- a/src/main/java/com/brainpix/joining/repository/RequestTaskPurchasingRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/RequestTaskPurchasingRepository.java
@@ -1,7 +1,7 @@
 package com.brainpix.joining.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,8 +13,9 @@ public interface RequestTaskPurchasingRepository
 	extends JpaRepository<RequestTaskPurchasing, Long> {
 
 	// "수락" 상태(accepted = true) 리스트
-	List<RequestTaskPurchasing> findByBuyerAndAcceptedIsTrue(User buyer);
+	Page<RequestTaskPurchasing> findByBuyerAndAcceptedIsTrue(User buyer, Pageable pageable);
 
 	// "거절" 상태(accepted = false) 리스트
-	List<RequestTaskPurchasing> findByBuyerAndAcceptedIsFalse(User buyer);
+	Page<RequestTaskPurchasing> findByBuyerAndAcceptedIsFalse(User buyer, Pageable pageable);
+
 }

--- a/src/main/java/com/brainpix/joining/repository/RequestTaskPurchasingRepository.java
+++ b/src/main/java/com/brainpix/joining/repository/RequestTaskPurchasingRepository.java
@@ -1,0 +1,20 @@
+package com.brainpix.joining.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.brainpix.joining.entity.purchasing.RequestTaskPurchasing;
+import com.brainpix.user.entity.User;
+
+@Repository
+public interface RequestTaskPurchasingRepository
+	extends JpaRepository<RequestTaskPurchasing, Long> {
+
+	// "수락" 상태(accepted = true) 리스트
+	List<RequestTaskPurchasing> findByBuyerAndAcceptedIsTrue(User buyer);
+
+	// "거절" 상태(accepted = false) 리스트
+	List<RequestTaskPurchasing> findByBuyerAndAcceptedIsFalse(User buyer);
+}

--- a/src/main/java/com/brainpix/joining/service/SupportCollaborationService.java
+++ b/src/main/java/com/brainpix/joining/service/SupportCollaborationService.java
@@ -1,0 +1,101 @@
+package com.brainpix.joining.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.brainpix.joining.converter.CollectionGatheringConverter;
+import com.brainpix.joining.dto.AcceptedCollaborationDto;
+import com.brainpix.joining.dto.RejectedCollaborationDto;
+import com.brainpix.joining.dto.TeamMemberInfoDto;
+import com.brainpix.joining.entity.purchasing.CollectionGathering;
+import com.brainpix.joining.repository.CollectionGatheringRepository;
+import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
+import com.brainpix.user.entity.User;
+import com.brainpix.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SupportCollaborationService {
+
+	private final CollectionGatheringRepository gatheringRepository;
+	private final CollectionGatheringConverter converter;
+	private final UserRepository userRepository;
+
+	/**
+	 * [1] 거절 목록 조회
+	 * - accepted = false
+	 * - joiner = currentUser
+	 */
+	@Transactional(readOnly = true)
+	public List<RejectedCollaborationDto> getRejectedList(Long userId) {
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
+
+		// "거절" 상태: accepted = false
+		List<CollectionGathering> rejectedList =
+			gatheringRepository.findByJoinerAndAcceptedIsFalse(currentUser);
+
+		// 엔티티 -> DTO 변환
+		return rejectedList.stream()
+			.map(converter::toRejectedDto)
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * [2] 수락 목록 조회
+	 * - accepted = true
+	 * - joiner = currentUser
+	 * - 팀원 정보까지 추가
+	 */
+	@Transactional(readOnly = true)
+	public List<AcceptedCollaborationDto> getAcceptedList(Long userId) {
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
+
+		// "수락" 상태: accepted = true
+		List<CollectionGathering> acceptedList =
+			gatheringRepository.findByJoinerAndAcceptedIsTrue(currentUser);
+
+		// 각 CollectionGathering 마다,
+		//  -> 해당 CollaborationHub의 teamInfoList를 구성
+		return acceptedList.stream()
+			.map(cg -> {
+				CollaborationHub hub = cg.getCollaborationRecruitment()
+					.getParentCollaborationHub();
+				// 팀원 정보 생성
+				List<TeamMemberInfoDto> teamInfo =
+					converter.createTeamInfoList(hub);
+
+				// 최종 DTO
+				return converter.toAcceptedDto(cg, teamInfo);
+			})
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * [3] 거절 항목 삭제 (DB 물리 삭제했습니다.)
+	 */
+	@Transactional
+	public void deleteRejected(Long userId, Long collectionGatheringId) {
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
+
+		CollectionGathering cg = gatheringRepository.findById(collectionGatheringId)
+			.orElseThrow(() -> new RuntimeException("지원 내역이 존재하지 않습니다."));
+
+		// 본인 항목인지 + 거절 상태인지 확인
+		if (!cg.getJoiner().equals(currentUser)) {
+			throw new RuntimeException("본인이 지원한 항목이 아닙니다.");
+		}
+		if (Boolean.TRUE.equals(cg.getAccepted())) {
+			throw new RuntimeException("거절 상태가 아닌 항목은 삭제할 수 없습니다.");
+		}
+
+		gatheringRepository.delete(cg);
+	}
+}

--- a/src/main/java/com/brainpix/joining/service/SupportIdeaMarketService.java
+++ b/src/main/java/com/brainpix/joining/service/SupportIdeaMarketService.java
@@ -2,6 +2,7 @@ package com.brainpix.joining.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +13,7 @@ import com.brainpix.joining.converter.IdeaMarketPurchasingConverter;
 import com.brainpix.joining.dto.IdeaMarketPurchaseDto;
 import com.brainpix.joining.entity.purchasing.IdeaMarketPurchasing;
 import com.brainpix.joining.repository.IdeaMarketPurchasingRepository;
+import com.brainpix.joining.util.PageableUtils;
 import com.brainpix.user.entity.User;
 import com.brainpix.user.repository.UserRepository;
 
@@ -31,10 +33,12 @@ public class SupportIdeaMarketService {
 		User currentUser = userRepository.findById(userId)
 			.orElseThrow(() -> new BrainPixException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-		// 구매내역
-		Page<IdeaMarketPurchasing> page = purchasingRepository.findByBuyer(currentUser, pageable);
+		Pageable sortedPageable = PageableUtils.withSort(pageable, "createdAt", Sort.Direction.DESC);
 
-		Page<IdeaMarketPurchaseDto> dtoPage = page.map(converter::toPurchaseDto);
+		// 구매내역
+		Page<IdeaMarketPurchasing> purchasings = purchasingRepository.findByBuyer(currentUser, sortedPageable);
+
+		Page<IdeaMarketPurchaseDto> dtoPage = purchasings.map(converter::toPurchaseDto);
 
 		return CommonPageResponse.of(dtoPage);
 	}

--- a/src/main/java/com/brainpix/joining/service/SupportIdeaMarketService.java
+++ b/src/main/java/com/brainpix/joining/service/SupportIdeaMarketService.java
@@ -1,0 +1,42 @@
+package com.brainpix.joining.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.brainpix.api.code.error.CommonErrorCode;
+import com.brainpix.api.exception.BrainPixException;
+import com.brainpix.joining.converter.IdeaMarketPurchasingConverter;
+import com.brainpix.joining.dto.IdeaMarketPurchaseDto;
+import com.brainpix.joining.entity.purchasing.IdeaMarketPurchasing;
+import com.brainpix.joining.repository.IdeaMarketPurchasingRepository;
+import com.brainpix.user.entity.User;
+import com.brainpix.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SupportIdeaMarketService {
+
+	private final UserRepository userRepository;
+	private final IdeaMarketPurchasingRepository purchasingRepository;
+	private final IdeaMarketPurchasingConverter converter;
+
+	@Transactional(readOnly = true)
+	public List<IdeaMarketPurchaseDto> getMyPurchases(Long userId) {
+		// 1) 유저
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new BrainPixException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		// 2) 구매 내역
+		List<IdeaMarketPurchasing> list = purchasingRepository.findByBuyer(currentUser);
+
+		// 3) 변환
+		return list.stream()
+			.map(converter::toPurchaseDto)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/brainpix/joining/service/SupportIdeaMarketService.java
+++ b/src/main/java/com/brainpix/joining/service/SupportIdeaMarketService.java
@@ -1,11 +1,11 @@
 package com.brainpix.joining.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.brainpix.api.CommonPageResponse;
 import com.brainpix.api.code.error.CommonErrorCode;
 import com.brainpix.api.exception.BrainPixException;
 import com.brainpix.joining.converter.IdeaMarketPurchasingConverter;
@@ -26,17 +26,17 @@ public class SupportIdeaMarketService {
 	private final IdeaMarketPurchasingConverter converter;
 
 	@Transactional(readOnly = true)
-	public List<IdeaMarketPurchaseDto> getMyPurchases(Long userId) {
-		// 1) 유저
+	public CommonPageResponse<IdeaMarketPurchaseDto> getMyPurchases(Long userId, Pageable pageable) {
+		// 유저
 		User currentUser = userRepository.findById(userId)
 			.orElseThrow(() -> new BrainPixException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-		// 2) 구매 내역
-		List<IdeaMarketPurchasing> list = purchasingRepository.findByBuyer(currentUser);
+		// 구매내역
+		Page<IdeaMarketPurchasing> page = purchasingRepository.findByBuyer(currentUser, pageable);
 
-		// 3) 변환
-		return list.stream()
-			.map(converter::toPurchaseDto)
-			.collect(Collectors.toList());
+		Page<IdeaMarketPurchaseDto> dtoPage = page.map(converter::toPurchaseDto);
+
+		return CommonPageResponse.of(dtoPage);
 	}
+
 }

--- a/src/main/java/com/brainpix/joining/service/SupportRequestTaskService.java
+++ b/src/main/java/com/brainpix/joining/service/SupportRequestTaskService.java
@@ -1,11 +1,14 @@
 package com.brainpix.joining.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.brainpix.api.CommonPageResponse;
+import com.brainpix.api.code.error.PurchasingErrorCode;
+import com.brainpix.api.code.error.RequestTaskErrorCode;
+import com.brainpix.api.exception.BrainPixException;
 import com.brainpix.joining.converter.RequestTaskPurchasingConverter;
 import com.brainpix.joining.dto.AcceptedRequestTaskPurchasingDto;
 import com.brainpix.joining.dto.RejectedRequestTaskPurchasingDto;
@@ -28,34 +31,31 @@ public class SupportRequestTaskService {
 	 * 거절 목록 조회
 	 */
 	@Transactional(readOnly = true)
-	public List<RejectedRequestTaskPurchasingDto> getRejectedList(Long userId) {
+	public CommonPageResponse<RejectedRequestTaskPurchasingDto> getRejectedList(Long userId, Pageable pageable) {
 		User currentUser = userRepository.findById(userId)
-			.orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+			.orElseThrow(() -> new BrainPixException(RequestTaskErrorCode.USER_NOT_FOUND));
 
-		// "accepted = false" 목록 가져오기
-		List<RequestTaskPurchasing> rejectedList =
-			purchasingRepository.findByBuyerAndAcceptedIsFalse(currentUser);
+		// Fetch paginated list of rejected requests
+		Page<RequestTaskPurchasing> rejectedPage =
+			purchasingRepository.findByBuyerAndAcceptedIsFalse(currentUser, pageable);
 
-		// 변환 로직 -> converter 사용
-		return rejectedList.stream()
-			.map(converter::toRejectedDto) // 메서드 레퍼런스
-			.collect(Collectors.toList());
+		// Convert to DTOs and wrap in CommonPageResponse
+		Page<RejectedRequestTaskPurchasingDto> dtoPage = rejectedPage.map(converter::toRejectedDto);
+		return CommonPageResponse.of(dtoPage);
 	}
 
-	/**
-	 * 수락 목록 조회
-	 */
 	@Transactional(readOnly = true)
-	public List<AcceptedRequestTaskPurchasingDto> getAcceptedList(Long userId) {
+	public CommonPageResponse<AcceptedRequestTaskPurchasingDto> getAcceptedList(Long userId, Pageable pageable) {
 		User currentUser = userRepository.findById(userId)
-			.orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+			.orElseThrow(() -> new BrainPixException(RequestTaskErrorCode.USER_NOT_FOUND));
 
-		List<RequestTaskPurchasing> acceptedList =
-			purchasingRepository.findByBuyerAndAcceptedIsTrue(currentUser);
+		// Fetch paginated list of accepted requests
+		Page<RequestTaskPurchasing> acceptedPage =
+			purchasingRepository.findByBuyerAndAcceptedIsTrue(currentUser, pageable);
 
-		return acceptedList.stream()
-			.map(converter::toAcceptedDto)
-			.collect(Collectors.toList());
+		// Convert to DTOs and wrap in CommonPageResponse
+		Page<AcceptedRequestTaskPurchasingDto> dtoPage = acceptedPage.map(converter::toAcceptedDto);
+		return CommonPageResponse.of(dtoPage);
 	}
 
 	/**
@@ -64,19 +64,18 @@ public class SupportRequestTaskService {
 	@Transactional
 	public void deleteRejectedPurchasing(Long userId, Long purchasingId) {
 		User currentUser = userRepository.findById(userId)
-			.orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+			.orElseThrow(() -> new BrainPixException(RequestTaskErrorCode.USER_NOT_FOUND));
 
 		RequestTaskPurchasing purchasing = purchasingRepository.findById(purchasingId)
-			.orElseThrow(() -> new RuntimeException("지원 내역이 존재하지 않습니다."));
-
+			.orElseThrow(() -> new BrainPixException(PurchasingErrorCode.COLLECTION_NOT_FOUND));
 		// 본인이 지원한 항목인지 확인
 		if (!purchasing.getBuyer().equals(currentUser)) {
-			throw new RuntimeException("본인이 지원한 항목이 아닙니다.");
+			throw new BrainPixException(PurchasingErrorCode.NOT_AUTHORIZED);
 		}
 
 		// 거절 상태인지 확인
 		if (Boolean.TRUE.equals(purchasing.getAccepted())) {
-			throw new RuntimeException("거절 상태가 아닌 항목은 삭제할 수 없습니다.");
+			throw new BrainPixException(PurchasingErrorCode.INVALID_STATUS);
 		}
 
 		// DB에서 실제 삭제

--- a/src/main/java/com/brainpix/joining/service/SupportRequestTaskService.java
+++ b/src/main/java/com/brainpix/joining/service/SupportRequestTaskService.java
@@ -1,0 +1,85 @@
+package com.brainpix.joining.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.brainpix.joining.converter.RequestTaskPurchasingConverter;
+import com.brainpix.joining.dto.AcceptedRequestTaskPurchasingDto;
+import com.brainpix.joining.dto.RejectedRequestTaskPurchasingDto;
+import com.brainpix.joining.entity.purchasing.RequestTaskPurchasing;
+import com.brainpix.joining.repository.RequestTaskPurchasingRepository;
+import com.brainpix.user.entity.User;
+import com.brainpix.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SupportRequestTaskService {
+
+	private final RequestTaskPurchasingRepository purchasingRepository;
+	private final UserRepository userRepository;
+	private final RequestTaskPurchasingConverter converter;
+
+	/**
+	 * 거절 목록 조회
+	 */
+	@Transactional(readOnly = true)
+	public List<RejectedRequestTaskPurchasingDto> getRejectedList(Long userId) {
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+		// "accepted = false" 목록 가져오기
+		List<RequestTaskPurchasing> rejectedList =
+			purchasingRepository.findByBuyerAndAcceptedIsFalse(currentUser);
+
+		// 변환 로직 -> converter 사용
+		return rejectedList.stream()
+			.map(converter::toRejectedDto) // 메서드 레퍼런스
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * 수락 목록 조회
+	 */
+	@Transactional(readOnly = true)
+	public List<AcceptedRequestTaskPurchasingDto> getAcceptedList(Long userId) {
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+		List<RequestTaskPurchasing> acceptedList =
+			purchasingRepository.findByBuyerAndAcceptedIsTrue(currentUser);
+
+		return acceptedList.stream()
+			.map(converter::toAcceptedDto)
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * 거절된 지원 삭제(물리적으로 DB에서 제거)
+	 */
+	@Transactional
+	public void deleteRejectedPurchasing(Long userId, Long purchasingId) {
+		User currentUser = userRepository.findById(userId)
+			.orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
+
+		RequestTaskPurchasing purchasing = purchasingRepository.findById(purchasingId)
+			.orElseThrow(() -> new RuntimeException("지원 내역이 존재하지 않습니다."));
+
+		// 본인이 지원한 항목인지 확인
+		if (!purchasing.getBuyer().equals(currentUser)) {
+			throw new RuntimeException("본인이 지원한 항목이 아닙니다.");
+		}
+
+		// 거절 상태인지 확인
+		if (Boolean.TRUE.equals(purchasing.getAccepted())) {
+			throw new RuntimeException("거절 상태가 아닌 항목은 삭제할 수 없습니다.");
+		}
+
+		// DB에서 실제 삭제
+		purchasingRepository.delete(purchasing);
+	}
+}

--- a/src/main/java/com/brainpix/joining/util/PageableUtils.java
+++ b/src/main/java/com/brainpix/joining/util/PageableUtils.java
@@ -1,0 +1,16 @@
+package com.brainpix.joining.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class PageableUtils {
+
+	public static Pageable withSort(Pageable pageable, String sortBy, Sort.Direction direction) {
+		return PageRequest.of(
+			pageable.getPageNumber(),
+			pageable.getPageSize(),
+			Sort.by(direction, sortBy)
+		);
+	}
+}

--- a/src/main/java/com/brainpix/post/entity/collaboration_hub/CollaborationRecruitment.java
+++ b/src/main/java/com/brainpix/post/entity/collaboration_hub/CollaborationRecruitment.java
@@ -1,5 +1,9 @@
 package com.brainpix.post.entity.collaboration_hub;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.brainpix.joining.entity.purchasing.CollectionGathering;
 import com.brainpix.joining.entity.quantity.Gathering;
 import com.brainpix.jpa.BaseTimeEntity;
 
@@ -8,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +33,9 @@ public class CollaborationRecruitment extends BaseTimeEntity {
 
 	@OneToOne
 	private Gathering gathering;
+
+	@OneToMany(mappedBy = "collaborationRecruitment")
+	private List<CollectionGathering> collectionGatherings = new ArrayList<>();
 
 	@Builder
 	public CollaborationRecruitment(CollaborationHub parentCollaborationHub, String domain, Gathering gathering) {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #59

## ✨ PR 세부 내용
- 지원 현황 기능을 아이디어마켓, 협업 광장, 요청 과제로 나누어 구현했습니다.
- 각 도메인별로 본인이 지원(또는 구매)한 목록을 조회하고, 필요 시 거절 항목을 영구 삭제할 수 있도록 했습니다.


<분야 별 내용>
1. 아이디어마켓: 구매 목록 조회
2. 협업 광장: 거절/수락 목록 조회, 거절 항목 삭제 (팀원 정보 표시)
3. 요청 과제: 거절/수락 목록 조회, 거절 항목 삭제
<!-- 수정/추가한 내용을 적어주세요. -->
