### PR TITLE
[FEAT] 로그인 처리를 위한 메일 전송 구현 ($76)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -56,6 +57,9 @@ dependencies {
 
     // 스웨거 의존성
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // mail 전송을 위한 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/brainpix/api/code/error/MailErrorCode.java
+++ b/src/main/java/com/brainpix/api/code/error/MailErrorCode.java
@@ -1,0 +1,16 @@
+package com.brainpix.api.code.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MailErrorCode implements ErrorCode {
+	MAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500", "메일 전송에 실패했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/brainpix/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/brainpix/config/KafkaConsumerConfig.java
@@ -22,7 +22,7 @@ public class KafkaConsumerConfig {
 		config.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group");
 		config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.brainpix.alarm.dto");
+		config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
 		return new DefaultKafkaConsumerFactory<>(config);
 	}
 

--- a/src/main/java/com/brainpix/config/MailConfig.java
+++ b/src/main/java/com/brainpix/config/MailConfig.java
@@ -1,0 +1,42 @@
+package com.brainpix.config;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+	private final String HOST;
+	private final String USERNAME;
+	private final String PASSWORD;
+
+	public MailConfig(@Value("${spring.mail.password}") String HOST,
+		@Value("${spring.mail.username}") String USERNAME,
+		@Value("${spring.mail.host}") String PASSWORD) {
+		this.HOST = HOST;
+		this.USERNAME = USERNAME;
+		this.PASSWORD = PASSWORD;
+	}
+
+	@Bean
+	public JavaMailSender javaMailSender() {
+		JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+		javaMailSender.setHost(HOST);
+		javaMailSender.setPort(587);
+		javaMailSender.setUsername(USERNAME);
+		javaMailSender.setPassword(PASSWORD);
+
+		Properties properties = new Properties();
+		properties.put("mail.smtp.auth", true);
+		properties.put("mail.smtp.timeout", 5000);
+		properties.put("mail.smtp.starttls.enable", true);
+		javaMailSender.setJavaMailProperties(properties);
+
+		return javaMailSender;
+	}
+}

--- a/src/main/java/com/brainpix/kafka/service/MailEventListener.java
+++ b/src/main/java/com/brainpix/kafka/service/MailEventListener.java
@@ -1,0 +1,29 @@
+package com.brainpix.kafka.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import com.brainpix.api.exception.BrainPixException;
+import com.brainpix.mail.dto.SendMailDto;
+import com.brainpix.mail.service.MailService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailEventListener {
+
+	private final MailService mailService;
+
+	@KafkaListener(topics = "send-mail", groupId = "test-group")
+	public void listenMailEvent(SendMailDto request) {
+		try {
+			mailService.sendMail(request);
+		} catch (BrainPixException e) {
+			log.error("failed to send mail to {}", request.getReceiverEmail());
+		}
+		log.info("received and send mail to {}", request.getReceiverEmail());
+	}
+}

--- a/src/main/java/com/brainpix/kafka/service/MailEventService.java
+++ b/src/main/java/com/brainpix/kafka/service/MailEventService.java
@@ -1,0 +1,22 @@
+package com.brainpix.kafka.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.brainpix.mail.dto.SendMailDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailEventService {
+
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	public void sendMailEvent(SendMailDto request) {
+		kafkaTemplate.send("send-mail", request);
+		log.info("sending mail event to {}", request.getReceiverEmail());
+	}
+}

--- a/src/main/java/com/brainpix/mail/controller/MailController.java
+++ b/src/main/java/com/brainpix/mail/controller/MailController.java
@@ -1,0 +1,49 @@
+package com.brainpix.mail.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.brainpix.api.ApiResponse;
+import com.brainpix.kafka.service.MailEventService;
+import com.brainpix.mail.dto.SendMailDto;
+import com.brainpix.mail.service.MailService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mail")
+public class MailController {
+
+	private final MailService mailService;
+	private final MailEventService mailEventService;
+
+	@PostMapping("/test")
+	public ResponseEntity<?> sendMail(@RequestParam String to, @RequestParam String subject) {
+		SendMailDto request = SendMailDto.builder()
+			.receiverEmail(to)
+			.title(subject)
+			.signupCode("test")
+			.build();
+
+		mailService.sendMail(request);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+
+	@PostMapping("/kafka/test")
+	public ResponseEntity<?> sendMailKafka(@RequestParam String to, @RequestParam String subject) {
+		SendMailDto request = SendMailDto.builder()
+			.receiverEmail(to)
+			.title(subject)
+			.signupCode("test")
+			.build();
+
+		mailEventService.sendMailEvent(request);
+
+		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	}
+}

--- a/src/main/java/com/brainpix/mail/dto/SendMailDto.java
+++ b/src/main/java/com/brainpix/mail/dto/SendMailDto.java
@@ -1,0 +1,14 @@
+package com.brainpix.mail.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+public class SendMailDto {
+	private final String receiverEmail;
+	private final String signupCode;
+	private final String title;
+}

--- a/src/main/java/com/brainpix/mail/service/MailService.java
+++ b/src/main/java/com/brainpix/mail/service/MailService.java
@@ -1,0 +1,34 @@
+package com.brainpix.mail.service;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import com.brainpix.api.code.error.MailErrorCode;
+import com.brainpix.api.exception.BrainPixException;
+import com.brainpix.mail.dto.SendMailDto;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+	private final JavaMailSender javaMailSender;
+
+	public void sendMail(SendMailDto request) {
+		MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+		try {
+			MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false , "UTF-8");
+			mimeMessageHelper.setTo(request.getReceiverEmail());
+			mimeMessageHelper.setSubject(request.getTitle());
+			mimeMessageHelper.setText(request.getSignupCode(), false);
+
+			javaMailSender.send(mimeMessage);
+		} catch (MessagingException e) {
+			throw new BrainPixException(MailErrorCode.MAIL_SEND_FAILED);
+		}
+	}
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~
-->

## 📌 관련 이슈

- closed: #76 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
### 구현내용
JavaMailSender를 활용 해 SMTP로 메일을 전송하도록 구현했습니다
메일을 다 전송할 때까지 api응답이 3 - 5초 정도 소요되므로 메일 전송 서버를 따로 두어 메시지큐로 연동하도록 하였습니다
이메일 형식 검증은 가능하지만 해당 메일 주소가 실제로 유효한지 검증할 수 없어 그부분은 추후 고려해야 할 것 같습니다
### 설정
3개의 프로퍼티를 설정해야 합니다
- spring.mail.host
- spring.mail.username
- spring.mail.password

구글 smpt 서버를 기반으로 테스트했으므로 참고 부탁드립니다. 다른 smpt 서비스는 작동 여부를 테스트하지 않았습니다
### 사용방법
MailEventService의 sendMailEvent 메서드를 호출하여 메시지큐에 메시지를 전달한 후 응답을 하시면 됩니다
메시지를 받은 메일 전송 서버는 dto를 역직렬화 한 후 메일을 전송하게 됩니다
메일 발송 실패시 로직은 따로 작성하지 않았고, 로그만 출력하도록 하였습니다
즉, 메일 전송 성공 여부는 메일 발송 서버가 아니면 알 수 없으므로 그에 맞게 로직을 작성하시면 될 것 같습니다