### PR TITLE
[FEAT] 로그인하지 않은 사용자도 Authentication 가지도록 수정 (#113)

### DIFF
--- a/src/main/java/com/brainpix/security/authenticationToken/AnonymousAuthenticationToken.java
+++ b/src/main/java/com/brainpix/security/authenticationToken/AnonymousAuthenticationToken.java
@@ -1,0 +1,12 @@
+package com.brainpix.security.authenticationToken;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public class AnonymousAuthenticationToken extends BrainpixAuthenticationToken {
+	public AnonymousAuthenticationToken(Object principal, Object credentials,
+		Collection<? extends GrantedAuthority> authorities) {
+		super(principal, credentials, authorities, -1L);
+	}
+}

--- a/src/main/java/com/brainpix/security/authority/BrainpixAuthority.java
+++ b/src/main/java/com/brainpix/security/authority/BrainpixAuthority.java
@@ -3,7 +3,7 @@ package com.brainpix.security.authority;
 import org.springframework.security.core.GrantedAuthority;
 
 public enum BrainpixAuthority implements GrantedAuthority {
-	INDIVIDUAL, COMPANY;
+	INDIVIDUAL, COMPANY, ANONYMOUS;
 
 	@Override
 	public String getAuthority() {

--- a/src/main/java/com/brainpix/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/brainpix/security/filter/JwtAuthenticationFilter.java
@@ -31,7 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		FilterChain filterChain) throws ServletException, IOException {
 		String jwt = request.getHeader("Authorization");
 		if (jwt == null) {
-			BrainpixAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(null, null, List.of(BrainpixAuthority.ANONYMOUS))
+			BrainpixAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(null, null,
+				List.of(BrainpixAuthority.ANONYMOUS));
 			SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 			filterChain.doFilter(request, response);
 		} else {
@@ -46,7 +47,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			 * Jwt 토큰의 서명이 없는 경우
 			 *  JWT 토큰이 만료된 경우
 			 */ catch (SignatureException | UnsupportedJwtException | MalformedJwtException | ExpiredJwtException e) {
-				BrainpixAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(null, null, List.of(BrainpixAuthority.ANONYMOUS))
+				BrainpixAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(null, null,
+					List.of(BrainpixAuthority.ANONYMOUS));
 				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 				filterChain.doFilter(request, response);
 			}

--- a/src/main/java/com/brainpix/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/brainpix/security/filter/JwtAuthenticationFilter.java
@@ -1,11 +1,14 @@
 package com.brainpix.security.filter;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.brainpix.security.authenticationToken.AnonymousAuthenticationToken;
 import com.brainpix.security.authenticationToken.BrainpixAuthenticationToken;
+import com.brainpix.security.authority.BrainpixAuthority;
 import com.brainpix.security.tokenManger.TokenManager;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -28,6 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		FilterChain filterChain) throws ServletException, IOException {
 		String jwt = request.getHeader("Authorization");
 		if (jwt == null) {
+			BrainpixAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(null, null, List.of(BrainpixAuthority.ANONYMOUS))
+			SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 			filterChain.doFilter(request, response);
 		} else {
 			jwt = parseJwt(jwt);
@@ -41,6 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			 * Jwt 토큰의 서명이 없는 경우
 			 *  JWT 토큰이 만료된 경우
 			 */ catch (SignatureException | UnsupportedJwtException | MalformedJwtException | ExpiredJwtException e) {
+				BrainpixAuthenticationToken authenticationToken = new AnonymousAuthenticationToken(null, null, List.of(BrainpixAuthority.ANONYMOUS))
+				SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 				filterChain.doFilter(request, response);
 			}
 		}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #113 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
 로그인하지 않은 사용자도 Brainpix에서 정의한 Authentication 가지도록 수정하였습니다.