### PR TITLE
[FEAT] swagger 를 위한 pageable 전용 마커 어노테이션 추가

### DIFF
--- a/src/main/java/com/brainpix/api/swagger/SwaggerPageable.java
+++ b/src/main/java/com/brainpix/api/swagger/SwaggerPageable.java
@@ -1,0 +1,35 @@
+package com.brainpix.api.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameters({
+	@Parameter(
+		in = ParameterIn.QUERY,
+		name = "page",
+		description = "페이지 번호입니다.",
+		schema = @io.swagger.v3.oas.annotations.media.Schema(type = "integer", defaultValue = "0"),
+		required = true
+	),
+	@Parameter(
+		in = ParameterIn.QUERY,
+		name = "size",
+		description = "한 페이지에 표시될 데이터의 개수 입니다.",
+		schema = @io.swagger.v3.oas.annotations.media.Schema(type = "integer", defaultValue = "10"),
+		required = true
+	),
+	@Parameter(
+		name = "pageable",
+		hidden = true
+	)
+})
+public @interface SwaggerPageable {
+}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #134 

## ✨ PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
### 구현내용
controller에서 pageable을 받을때 swagger에서 프런트분들이 이해하기 쉽도록 하는 마커 어노테이션 추가
### 사용방법
```java
	@GetMapping
	@SwaggerPageable
	public ResponseEntity<ApiResponse<GetAlarmDto.Response>> getAlarmList(Pageable pageable, @RequestParam Long userId) {

		GetAlarmDto.Response data = alarmService.getAlarm(pageable, userId);

		return ResponseEntity.ok(ApiResponse.success(data));
	}
```
위와같이 pageable를 파라미터로 받는 메서드에 `@SwaggerPageable` 을 추가하시면 됩니다
### 적용전/적용후 비교
#### 적용전
![스크린샷 2025-02-05 오전 1 18 49](https://github.com/user-attachments/assets/3fea6b44-4fe8-4eb8-ba82-244bc6365dd2)
#### 적용후
![스크린샷 2025-02-05 오전 1 19 17](https://github.com/user-attachments/assets/32a588c3-79b6-4995-bfa4-92becacb2990)
### 참고
sort는 받지 않도록 설정했습니다