### PR TITLE
[FEAT] 게시글 저장 및 해제를 토글 형식으로 하도록 수정 (#151)

### DIFF
--- a/src/main/java/com/brainpix/post/controller/SavedPostController.java
+++ b/src/main/java/com/brainpix/post/controller/SavedPostController.java
@@ -14,26 +14,29 @@ import com.brainpix.api.CommonPageResponse;
 import com.brainpix.post.dto.PostCollaborationResponse;
 import com.brainpix.post.dto.PostIdeaMarketResponse;
 import com.brainpix.post.dto.PostRequestTaskResponse;
+import com.brainpix.post.dto.SavePostResponseDto;
 import com.brainpix.post.service.SavedPostService;
 import com.brainpix.security.authorization.AllUser;
 import com.brainpix.security.authorization.UserId;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/saved-posts")
 @RequiredArgsConstructor
+@Tag(name = "게시글 저장 관련 API", description = "게시글을 저장 및 해제 하고, 저장된 게시글을 조회하는 API입니다.")
 public class SavedPostController {
 
 	private final SavedPostService savedPostService;
 
-	@Operation(summary = "게시글 저장", description = "현재 로그인한 사용자가 특정 게시글을 저장합니다.")
+	@Operation(summary = "게시글 저장 및 해제", description = "토글 형식으로 현재 로그인한 사용자가 특정 게시글을 저장 또는 해제 합니다.<br>이미 저장된 게시글은 해제되고, 그렇지 않다면 저장합니다.")
 	@AllUser
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> savePost(@UserId Long userId, @RequestParam long postId) {
-		savedPostService.savePost(userId, postId);
-		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	public ResponseEntity<ApiResponse<SavePostResponseDto>> savePost(@UserId Long userId, @RequestParam long postId) {
+		SavePostResponseDto result = savedPostService.savePost(userId, postId);
+		return ResponseEntity.ok(ApiResponse.success(result));
 	}
 
 	@Operation(summary = "저장된 요청 과제 조회", description = "현재 로그인한 사용자가 저장한 요청 과제를 조회합니다.")

--- a/src/main/java/com/brainpix/post/dto/SavePostResponseDto.java
+++ b/src/main/java/com/brainpix/post/dto/SavePostResponseDto.java
@@ -1,0 +1,9 @@
+package com.brainpix.post.dto;
+
+public record SavePostResponseDto(
+	Boolean isSaved
+) {
+	public static SavePostResponseDto from(Boolean isSaved) {
+		return new SavePostResponseDto(isSaved);
+	}
+}

--- a/src/main/java/com/brainpix/post/repository/SavedPostRepository.java
+++ b/src/main/java/com/brainpix/post/repository/SavedPostRepository.java
@@ -1,5 +1,7 @@
 package com.brainpix.post.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.brainpix.post.entity.Post;
@@ -7,8 +9,8 @@ import com.brainpix.post.entity.SavedPost;
 import com.brainpix.user.entity.User;
 
 public interface SavedPostRepository extends JpaRepository<SavedPost, Long>, SavedPostRepositoryCustom {
-
-	boolean existsByUserAndPost(User user, Post post);
-
+	
 	Long countByPostId(Long postId);
+
+	Optional<SavedPost> findByUserAndPost(User user, Post post);
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #151 

## ✨ PR 세부 내용

- API 하나로 게시글의 저장과 해제를 할 수 있도록 기존 코드를 수정하였습니다.
- 반환 dto를 추가하여 저장이 된 것인지, 해제가 된 것인지 확인할 수 있도록 하였습니다.
