### PR TITLE
[FIX] 상대방(개인/기업) 프로필 조회 ,수락/거절, 메시지 API를 위한 페이지에 정보 역할의 응답값 추가

### DIFF
--- a/src/main/java/com/brainpix/joining/converter/CollectionGatheringConverter.java
+++ b/src/main/java/com/brainpix/joining/converter/CollectionGatheringConverter.java
@@ -32,6 +32,7 @@ public class CollectionGatheringConverter {
 			.postTitle(hub.getTitle())
 			.specialization(hub.getSpecialization())
 			.domain(recruitment.getDomain())
+			.collaborationId(hub.getId())
 			.build();
 	}
 
@@ -59,6 +60,7 @@ public class CollectionGatheringConverter {
 			.writerName(writerName)
 			.writerType(writerType)
 			.teamInfoList(teamInfoList)
+			.collaborationId(hub.getId())
 			.build();
 	}
 
@@ -84,15 +86,22 @@ public class CollectionGatheringConverter {
 		List<CollectionGathering> joined =
 			findAcceptedOrInitial(recruitment.getCollectionGatherings());
 
-		List<String> joinerIds = joined.stream()
-			.map(cg -> cg.getJoiner().getName())
+		List<TeamMemberInfoDto.JoinerInfo> joiners = joined.stream()
+			.map(cg -> {
+				User joiner = cg.getJoiner();
+				String userType = (joiner instanceof Individual) ? "개인" : "회사";
+				return TeamMemberInfoDto.JoinerInfo.builder()
+					.joinerID(joiner.getIdentifier())
+					.userType(userType)
+					.build();
+			})
 			.collect(Collectors.toList());
 
 		return TeamMemberInfoDto.builder()
 			.domain(recruitment.getDomain())
 			.occupied(occupied)
 			.total(total)
-			.joinerIds(joinerIds)
+			.joiners(joiners)
 			.build();
 	}
 

--- a/src/main/java/com/brainpix/joining/converter/IdeaMarketPurchasingConverter.java
+++ b/src/main/java/com/brainpix/joining/converter/IdeaMarketPurchasingConverter.java
@@ -41,6 +41,7 @@ public class IdeaMarketPurchasingConverter {
 			.quantity(purchasing.getQuantity())
 			.fee(purchasing.getVat())
 			.finalPrice(purchasing.getPrice())
+			.ideaMarketId(ideaMarket.getId())
 			.build();
 	}
 }

--- a/src/main/java/com/brainpix/joining/converter/RequestTaskPurchasingConverter.java
+++ b/src/main/java/com/brainpix/joining/converter/RequestTaskPurchasingConverter.java
@@ -29,6 +29,7 @@ public class RequestTaskPurchasingConverter {
 			.postTitle(requestTask.getTitle())
 			.specialization(requestTask.getSpecialization())
 			.domain(recruitment.getDomain())
+			.requestTaskId(requestTask.getId())
 			.build();
 	}
 
@@ -52,6 +53,7 @@ public class RequestTaskPurchasingConverter {
 			.domain(recruitment.getDomain())
 			.writerName(writerName)
 			.writerType(writerType)
+			.requestTaskId(requestTask.getId())
 			.build();
 	}
 }

--- a/src/main/java/com/brainpix/joining/dto/AcceptedCollaborationDto.java
+++ b/src/main/java/com/brainpix/joining/dto/AcceptedCollaborationDto.java
@@ -36,4 +36,5 @@ public class AcceptedCollaborationDto {
 
 	// 팀원 정보 (모든 도메인에 대한 현재인원/총인원 + 멤버)
 	private List<TeamMemberInfoDto> teamInfoList;
+	private Long collaborationId;
 }

--- a/src/main/java/com/brainpix/joining/dto/AcceptedRequestTaskPurchasingDto.java
+++ b/src/main/java/com/brainpix/joining/dto/AcceptedRequestTaskPurchasingDto.java
@@ -31,4 +31,5 @@ public class AcceptedRequestTaskPurchasingDto {
 	// 게시물 작성자 정보 (이름 + 개인/회사)
 	private String writerName;
 	private String writerType;            // "개인" or "회사"
+	private Long requestTaskId;
 }

--- a/src/main/java/com/brainpix/joining/dto/IdeaMarketPurchaseDto.java
+++ b/src/main/java/com/brainpix/joining/dto/IdeaMarketPurchaseDto.java
@@ -36,6 +36,7 @@ public class IdeaMarketPurchaseDto {
 	// 결제금액 계산
 	private Long fee;            // 수수료
 	private Long finalPrice;     // (price × quantity) + fee
+	private Long ideaMarketId;
 
 }
 

--- a/src/main/java/com/brainpix/joining/dto/RejectedCollaborationDto.java
+++ b/src/main/java/com/brainpix/joining/dto/RejectedCollaborationDto.java
@@ -27,4 +27,5 @@ public class RejectedCollaborationDto {
 	private String postTitle;             // 게시글 제목
 	private Specialization specialization;
 	private String domain;                // 지원한 파트
+	private Long collaborationId;
 }

--- a/src/main/java/com/brainpix/joining/dto/RejectedRequestTaskPurchasingDto.java
+++ b/src/main/java/com/brainpix/joining/dto/RejectedRequestTaskPurchasingDto.java
@@ -27,4 +27,5 @@ public class RejectedRequestTaskPurchasingDto {
 	private String postTitle;             // 게시글 제목
 	private Specialization specialization;
 	private String domain;                // 지원 파트 (ex: "디자이너")
+	private Long requestTaskId;
 }

--- a/src/main/java/com/brainpix/joining/dto/TeamMemberInfoDto.java
+++ b/src/main/java/com/brainpix/joining/dto/TeamMemberInfoDto.java
@@ -15,5 +15,14 @@ public class TeamMemberInfoDto {
 	private String domain;       // 역할 (예: "디자이너")
 	private Long occupied;       // 현재 인원수
 	private Long total;          // 모집 정원
-	private List<String> joinerIds; // 수락/초기멤버들의 아이디 목록
+	private List<JoinerInfo> joiners; // 수락/초기멤버들의 아이디 목록
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class JoinerInfo {
+		private String joinerID;
+		private String userType;
+	}
 }

--- a/src/main/java/com/brainpix/post/dto/mypostdto/CollaborationApplicationStatusResponse.java
+++ b/src/main/java/com/brainpix/post/dto/mypostdto/CollaborationApplicationStatusResponse.java
@@ -6,7 +6,8 @@ public record CollaborationApplicationStatusResponse(
 	String applicantId, // 지원자 ID
 	String role, // 지원한 역할
 	Long approvedCount, // 현재 승인된 인원
-	Long totalCount // 해당 역할에서 모집 인원
+	Long totalCount,// 해당 역할에서 모집 인원
+	Long gatheringId
 ) {
 	public static CollaborationApplicationStatusResponse from(CollectionGathering collectionGathering) {
 
@@ -14,7 +15,8 @@ public record CollaborationApplicationStatusResponse(
 			collectionGathering.getJoiner().getIdentifier(),
 			collectionGathering.getCollaborationRecruitment().getDomain(),
 			collectionGathering.getCollaborationRecruitment().getGathering().getOccupiedQuantity(),
-			collectionGathering.getCollaborationRecruitment().getGathering().getTotalQuantity()
+			collectionGathering.getCollaborationRecruitment().getGathering().getTotalQuantity(),
+			collectionGathering.getId()
 		);
 	}
 }

--- a/src/main/java/com/brainpix/post/dto/mypostdto/CollaborationCurrentMemberResponse.java
+++ b/src/main/java/com/brainpix/post/dto/mypostdto/CollaborationCurrentMemberResponse.java
@@ -5,13 +5,20 @@ import java.util.List;
 public record CollaborationCurrentMemberResponse(
 	String role, // 역할
 	int approvedCount, // 현재 승인된 인원 수
-	List<String> memberId // 승인된 멤버 ID
+	List<AcceptedInfo> memberId // 승인된 멤버 ID
 ) {
-	public static CollaborationCurrentMemberResponse from(String role, List<String> memberId) {
+	public static CollaborationCurrentMemberResponse from(String role, List<AcceptedInfo> members) {
 		return new CollaborationCurrentMemberResponse(
 			role,
-			memberId.size(),
-			memberId
+			members.size(),
+			members
 		);
 	}
+
+	public record AcceptedInfo(String id, String userType, Long userId) {
+		public static AcceptedInfo from(String id, String userType, Long userId) {
+			return new AcceptedInfo(id, userType, userId);
+		}
+	}
+
 }

--- a/src/main/java/com/brainpix/post/dto/mypostdto/PurchaseInfoResponse.java
+++ b/src/main/java/com/brainpix/post/dto/mypostdto/PurchaseInfoResponse.java
@@ -3,7 +3,8 @@ package com.brainpix.post.dto.mypostdto;
 import com.brainpix.joining.entity.purchasing.Payment;
 
 public record PurchaseInfoResponse(
-	String buyerId,      // 구매자 아이디
+	String buyerID,      // 구매자 아이디
+	Long userId,
 	Payment payment, // 거래 방식 (예: 신용카드, 계좌이체 등)
 	Long totalPay      // 지불 금액
 ) {

--- a/src/main/java/com/brainpix/post/dto/mypostdto/RequestTaskApplicationStatusResponse.java
+++ b/src/main/java/com/brainpix/post/dto/mypostdto/RequestTaskApplicationStatusResponse.java
@@ -6,7 +6,8 @@ public record RequestTaskApplicationStatusResponse(
 	String applicantId, // 지원자 ID
 	String role, // 지원한 역할
 	Long approvedCount, // 현재 승인된 인원
-	Long totalCount // 해당 역할에서 모집 인원
+	Long totalCount, // 해당 역할에서 모집 인원
+	Long purchasingId
 ) {
 	public static RequestTaskApplicationStatusResponse from(RequestTaskPurchasing purchasing) {
 
@@ -14,7 +15,8 @@ public record RequestTaskApplicationStatusResponse(
 			purchasing.getBuyer().getIdentifier(),
 			purchasing.getRequestTaskRecruitment().getDomain(),
 			purchasing.getRequestTaskRecruitment().getPrice().getOccupiedQuantity(),
-			purchasing.getRequestTaskRecruitment().getPrice().getTotalQuantity()
+			purchasing.getRequestTaskRecruitment().getPrice().getTotalQuantity(),
+			purchasing.getId()
 		);
 	}
 }

--- a/src/main/java/com/brainpix/post/dto/mypostdto/RequestTaskCurrentMemberResponse.java
+++ b/src/main/java/com/brainpix/post/dto/mypostdto/RequestTaskCurrentMemberResponse.java
@@ -5,13 +5,23 @@ import java.util.List;
 public record RequestTaskCurrentMemberResponse(
 	String role, // 역할
 	int approvedCount, // 현재 승인된 인원 수
-	List<String> memberId // 승인된 멤버 ID
+	List<AcceptedInfo> memberId // 승인된 멤버 ID
 ) {
-	public static RequestTaskCurrentMemberResponse from(String role, List<String> memberId) {
+	public static RequestTaskCurrentMemberResponse from(String role, List<AcceptedInfo> members) {
 		return new RequestTaskCurrentMemberResponse(
 			role,
-			memberId.size(),
-			memberId
+			members.size(),
+			members
 		);
+	}
+
+	public record AcceptedInfo(
+		String id,
+		String userType,
+		Long acceptedMemberId
+	) {
+		public static AcceptedInfo from(String id, String userType, Long acceptedMemberId) {
+			return new AcceptedInfo(id, userType, acceptedMemberId);
+		}
 	}
 }

--- a/src/main/java/com/brainpix/post/service/mypost/MyCollaborationHubService.java
+++ b/src/main/java/com/brainpix/post/service/mypost/MyCollaborationHubService.java
@@ -19,6 +19,7 @@ import com.brainpix.post.dto.mypostdto.MyCollaborationHubDetailResponse;
 import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
 import com.brainpix.post.repository.CollaborationHubRepository;
 import com.brainpix.post.repository.SavedPostRepository;
+import com.brainpix.user.entity.Individual;
 import com.brainpix.user.entity.User;
 import com.brainpix.user.repository.UserRepository;
 
@@ -66,7 +67,12 @@ public class MyCollaborationHubService {
 				collection.getInitialGathering()))
 			.collect(Collectors.groupingBy(
 				collection -> collection.getCollaborationRecruitment().getDomain(),
-				Collectors.mapping(collection -> collection.getJoiner().getIdentifier(), Collectors.toList())
+				Collectors.mapping(collection -> {
+					User joiner = collection.getJoiner();
+					String userType = (joiner instanceof Individual) ? "개인" : "회사";
+					return CollaborationCurrentMemberResponse.AcceptedInfo.from(joiner.getIdentifier(), userType,
+						joiner.getId());
+				}, Collectors.toList())
 			))
 			.entrySet()
 			.stream()

--- a/src/main/java/com/brainpix/post/service/mypost/MyIdeaMarketService.java
+++ b/src/main/java/com/brainpix/post/service/mypost/MyIdeaMarketService.java
@@ -53,6 +53,7 @@ public class MyIdeaMarketService {
 			.stream()
 			.map(purchase -> new PurchaseInfoResponse(
 				purchase.getBuyer().getIdentifier(),
+				purchase.getBuyer().getId(),
 				purchase.getPayment(),
 				purchase.getPrice()
 			))

--- a/src/main/java/com/brainpix/post/service/mypost/MyRequestTaskService.java
+++ b/src/main/java/com/brainpix/post/service/mypost/MyRequestTaskService.java
@@ -19,6 +19,7 @@ import com.brainpix.post.dto.mypostdto.RequestTaskCurrentMemberResponse;
 import com.brainpix.post.entity.request_task.RequestTask;
 import com.brainpix.post.repository.RequestTaskRepository;
 import com.brainpix.post.repository.SavedPostRepository;
+import com.brainpix.user.entity.Individual;
 import com.brainpix.user.entity.User;
 import com.brainpix.user.repository.UserRepository;
 
@@ -63,9 +64,14 @@ public class MyRequestTaskService {
 			.findByRequestTaskRecruitmentInAndAcceptedTrue(requestTask.getRecruitments())
 			.stream()
 			.collect(Collectors.groupingBy(
-				purchasing -> purchasing.getRequestTaskRecruitment().getDomain(), //역할별 그룹화
-				Collectors.mapping(purchasing -> purchasing.getBuyer().getIdentifier(), Collectors.toList())
-				// 승인된 멤버 ID 리스트
+				collection -> collection.getRequestTaskRecruitment().getDomain(),
+				Collectors.mapping(collection -> {
+					User buyer = collection.getBuyer();
+					String userType = (buyer instanceof Individual) ? "개인" : "회사";
+					Long acceptedMemberId = buyer.getId();
+					return RequestTaskCurrentMemberResponse.AcceptedInfo.from(buyer.getIdentifier(), userType,
+						acceptedMemberId);
+				}, Collectors.toList())
 			))
 			.entrySet()
 			.stream()

--- a/src/main/java/com/brainpix/profile/converter/MyProfileConverter.java
+++ b/src/main/java/com/brainpix/profile/converter/MyProfileConverter.java
@@ -18,6 +18,7 @@ public class MyProfileConverter {
 		IndividualProfile profile = (IndividualProfile)user.getProfile();
 
 		return IndividualProfileResponseDto.builder()
+			.userId(user.getId())
 			.userType("개인")
 			.specializations(profile.getSpecializationList().stream()
 				.toList())
@@ -49,6 +50,7 @@ public class MyProfileConverter {
 		CompanyProfile profile = (CompanyProfile)user.getProfile();
 
 		return CompanyProfileResponseDto.builder()
+			.userId(user.getId())
 			.userType("기업")
 			.specializations(profile.getSpecializationList().stream()
 				.toList())

--- a/src/main/java/com/brainpix/profile/dto/CompanyProfileResponseDto.java
+++ b/src/main/java/com/brainpix/profile/dto/CompanyProfileResponseDto.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class CompanyProfileResponseDto {
+	private Long userId;
 	private String userType; // 개인/기업
 	private List<Specialization> specializations;
 	private String name; // 기업 이름

--- a/src/main/java/com/brainpix/profile/dto/IndividualProfileResponseDto.java
+++ b/src/main/java/com/brainpix/profile/dto/IndividualProfileResponseDto.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class IndividualProfileResponseDto {
+	private Long userId;
 	private String userType; // 개인/기업
 	private List<Specialization> specializations; // 전문 분야 (e.g., "IT/디자인")
 	private String name; // 사용자 이름


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #178 

## ✨ PR 세부 내용
다음과 같은 사항들이 기재된 페이지에 다음 API 선택하기 위한 추가 정보 제공했습니다. 
- 메시지 보내기
- 프로필 보기
- 수락/거절

<!-- 수정/추가한 내용을 적어주세요. -->
