### PR TITLE
[BUG] 상대방 프로필 조회 api의 url 수정 + 포트폴리오 조회를 타인 포폴까지 조회하도록 수정

### DIFF
--- a/src/main/java/com/brainpix/profile/controller/PortfolioController.java
+++ b/src/main/java/com/brainpix/profile/controller/PortfolioController.java
@@ -79,17 +79,16 @@ public class PortfolioController {
 	}
 
 	@AllUser
-	@Operation(summary = "내 포트폴리오 목록 조회", description = "사용자 ID를 기준으로 포트폴리오 목록을 페이징 처리하여 조회합니다.")
-	@GetMapping
+	@Operation(summary = "사용자의 포트폴리오 목록 조회",
+		description = "특정 사용자의 포트폴리오 목록을 조회합니다. 자신의 포트폴리오를 조회하려면 자신의 userId를 전달하세요.")
+	@GetMapping("/{userId}")
 	@SwaggerPageable
-	public ResponseEntity<CommonPageResponse<PortfolioResponse>> findMyPortfolios(
-		@UserId Long userId,
+	public ResponseEntity<CommonPageResponse<PortfolioResponse>> findPortfolios(
+		@PathVariable Long userId,
 		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		Page<PortfolioResponse> page = portfolioService.findAllMyPortfolios(userId, pageable);
-
+		Page<PortfolioResponse> page = portfolioService.findAllPortfoliosByUserId(userId, pageable);
 		CommonPageResponse<PortfolioResponse> response = CommonPageResponse.of(page);
-
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/main/java/com/brainpix/profile/controller/PublicProfileController.java
+++ b/src/main/java/com/brainpix/profile/controller/PublicProfileController.java
@@ -35,7 +35,7 @@ public class PublicProfileController {
 	 */
 	@AllUser
 	@Operation(summary = "개인 공개 프로필 조회", description = "특정 사용자에게 공개 개인 프로필을 조회합니다.")
-	@GetMapping("/individual")
+	@GetMapping("/individual/{userId}")
 	public ResponseEntity<ApiResponse<IndividualProfileResponseDto>> getPublicIndividualProfile(
 		@PathVariable Long userId) {
 		IndividualProfileResponseDto profile = publicProfileService.getPublicIndividualProfile(userId);
@@ -47,7 +47,7 @@ public class PublicProfileController {
 	 */
 	@AllUser
 	@Operation(summary = "기업 공개 프로필 조회", description = "특정 사용자에게 공개 기업 프로필을 조회합니다.")
-	@GetMapping("/company")
+	@GetMapping("/company/{userId}")
 	public ResponseEntity<ApiResponse<CompanyProfileResponseDto>> getPublicCompanyProfile(@PathVariable Long userId) {
 		CompanyProfileResponseDto profile = publicProfileService.getPublicCompanyProfile(userId);
 		return ResponseEntity.ok(ApiResponse.success(profile));
@@ -55,7 +55,7 @@ public class PublicProfileController {
 
 	@AllUser
 	@Operation(summary = "사용자 게시글 조회", description = "특정 사용자가 작성한 공개 게시글을 조회합니다.")
-	@GetMapping
+	@GetMapping("/{userId}")
 	@SwaggerPageable
 	public ResponseEntity<ApiResponse<CommonPageResponse<PublicProfileResponseDto.PostPreviewDto>>> getPostsByUser(
 		@PathVariable Long userId,

--- a/src/main/java/com/brainpix/profile/dto/MyPageResponseDto.java
+++ b/src/main/java/com/brainpix/profile/dto/MyPageResponseDto.java
@@ -17,4 +17,5 @@ public class MyPageResponseDto {
 	private long collaborationCount;    // 협업 경험 횟수
 	private String selfIntroduction;    // 자기소개
 	private String profileImage;
+	private Long userId;
 }

--- a/src/main/java/com/brainpix/profile/service/MyPageService.java
+++ b/src/main/java/com/brainpix/profile/service/MyPageService.java
@@ -57,6 +57,7 @@ public class MyPageService {
 			.collaborationCount(collaborationCount)
 			.selfIntroduction(selfIntroduction)
 			.profileImage(user.getProfileImage())
+			.userId(userId)
 			.build();
 	}
 

--- a/src/main/java/com/brainpix/profile/service/PortfolioService.java
+++ b/src/main/java/com/brainpix/profile/service/PortfolioService.java
@@ -67,7 +67,7 @@ public class PortfolioService {
 		portfolioRepository.delete(portfolio);
 	}
 
-	public Page<PortfolioResponse> findAllMyPortfolios(long userId, Pageable pageable) {
+	public Page<PortfolioResponse> findAllPortfoliosByUserId(Long userId, Pageable pageable) {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new BrainPixException(CommonErrorCode.USER_NOT_FOUND));
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #206 

## ✨ PR 세부 내용
수정 내용은 다음과 같습니다
- '마이페이지 조회' 응답값 추가 
- 상대방 프로필 조회 api에서 pathvariable 값을 url에 안넣어놔서 해당 내용 추가했습니다.
- 본인의 포트폴리오 조회만 가능했던 이전 api 에서 타인 포트폴리오까지 조회가능하도록 수정했습니다.
<!-- 수정/추가한 내용을 적어주세요. -->
