### PR TITLE
[BUG] API 충돌 해결 및 정렬 기준 수정

### DIFF
--- a/src/main/java/com/brainpix/profile/controller/PortfolioController.java
+++ b/src/main/java/com/brainpix/profile/controller/PortfolioController.java
@@ -81,7 +81,7 @@ public class PortfolioController {
 	@AllUser
 	@Operation(summary = "사용자의 포트폴리오 목록 조회",
 		description = "특정 사용자의 포트폴리오 목록을 조회합니다. 자신의 포트폴리오를 조회하려면 자신의 userId를 전달하세요.")
-	@GetMapping("/{userId}")
+	@GetMapping("/{userId}/list")
 	@SwaggerPageable
 	public ResponseEntity<CommonPageResponse<PortfolioResponse>> findPortfolios(
 		@PathVariable Long userId,

--- a/src/main/java/com/brainpix/profile/controller/PublicProfileController.java
+++ b/src/main/java/com/brainpix/profile/controller/PublicProfileController.java
@@ -59,7 +59,7 @@ public class PublicProfileController {
 	@SwaggerPageable
 	public ResponseEntity<ApiResponse<CommonPageResponse<PublicProfileResponseDto.PostPreviewDto>>> getPostsByUser(
 		@PathVariable Long userId,
-		@PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+		@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 		CommonPageResponse<PublicProfileResponseDto.PostPreviewDto> pageResponse =
 			CommonPageResponse.of(publicProfileService.getPostsByUser(userId, pageable));
 		return ResponseEntity.ok(ApiResponse.success(pageResponse));

--- a/src/main/java/com/brainpix/profile/service/PublicProfileService.java
+++ b/src/main/java/com/brainpix/profile/service/PublicProfileService.java
@@ -62,6 +62,8 @@ public class PublicProfileService {
 
 		// 비공개 항목 처리 (비공개면 빈 값/리스트 반환)
 		return IndividualProfileResponseDto.builder()
+			.userId(profileDto.getUserId())
+			.profileImage(profileDto.getProfileImage())
 			.userType(profileDto.getUserType())
 			.specializations(profileDto.getSpecializations())
 			.name(profileDto.getName())
@@ -91,6 +93,8 @@ public class PublicProfileService {
 		CompanyProfileResponseDto profileDto = myProfileConverter.toCompanyDto((Company)user);
 
 		return CompanyProfileResponseDto.builder()
+			.userId(profileDto.getUserId())
+			.imageUrl(profileDto.getImageUrl())
 			.userType(profileDto.getUserType())
 			.specializations(profileDto.getSpecializations())
 			.name(profileDto.getName())


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #208 

## ✨ PR 세부 내용
API 충돌 문제 해결 → /portfolios/{userId}와 /portfolios/{portfolioId} 완전히 구분
정렬 기준 오류 수정 → createdAt을 기준으로 올바르게 정렬

<!-- 수정/추가한 내용을 적어주세요. -->
