### PR TITLE
[BUG] gathering NPE방지를 위한 수정

### DIFF
--- a/src/main/java/com/brainpix/profile/converter/ProfilePostConverter.java
+++ b/src/main/java/com/brainpix/profile/converter/ProfilePostConverter.java
@@ -1,7 +1,10 @@
 package com.brainpix.profile.converter;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
+import com.brainpix.joining.entity.quantity.Gathering;
 import com.brainpix.post.entity.PostAuth;
 import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
 import com.brainpix.post.entity.idea_market.IdeaMarket;
@@ -59,10 +62,14 @@ public class ProfilePostConverter {
 	 */
 	public PublicProfileResponseDto.PostPreviewDto toCollaborationHubPreviewDto(CollaborationHub hub, long savedCount) {
 		long currentMembers = hub.getCollaborations().stream()
-			.mapToLong(rec -> rec.getGathering().getOccupiedQuantity())
+			.mapToLong(rec -> Optional.ofNullable(rec.getGathering())
+				.map(Gathering::getOccupiedQuantity)
+				.orElse(0L))
 			.sum();
 		long totalMembers = hub.getCollaborations().stream()
-			.mapToLong(rec -> rec.getGathering().getTotalQuantity())
+			.mapToLong(rec -> Optional.ofNullable(rec.getGathering())
+				.map(Gathering::getTotalQuantity)
+				.orElse(0L))
 			.sum();
 		String openScope = parseOpenScope(hub.getPostAuth());
 		String writerName = getDisplayName(hub.getWriter());

--- a/src/main/java/com/brainpix/profile/converter/ProfilePostConverter.java
+++ b/src/main/java/com/brainpix/profile/converter/ProfilePostConverter.java
@@ -1,10 +1,7 @@
 package com.brainpix.profile.converter;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Component;
 
-import com.brainpix.joining.entity.quantity.Gathering;
 import com.brainpix.post.entity.PostAuth;
 import com.brainpix.post.entity.collaboration_hub.CollaborationHub;
 import com.brainpix.post.entity.idea_market.IdeaMarket;
@@ -61,16 +58,8 @@ public class ProfilePostConverter {
 	 * 협업 광장 미리보기용 DTO 변환
 	 */
 	public PublicProfileResponseDto.PostPreviewDto toCollaborationHubPreviewDto(CollaborationHub hub, long savedCount) {
-		long currentMembers = hub.getCollaborations().stream()
-			.mapToLong(rec -> Optional.ofNullable(rec.getGathering())
-				.map(Gathering::getOccupiedQuantity)
-				.orElse(0L))
-			.sum();
-		long totalMembers = hub.getCollaborations().stream()
-			.mapToLong(rec -> Optional.ofNullable(rec.getGathering())
-				.map(Gathering::getTotalQuantity)
-				.orElse(0L))
-			.sum();
+		long currentMembers = hub.getOccupiedQuantity();
+		long totalMembers = hub.getTotalQuantity();
 		String openScope = parseOpenScope(hub.getPostAuth());
 		String writerName = getDisplayName(hub.getWriter());
 


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #issueNum

## ✨ PR 세부 내용
현재 협업광장 생성 시 두개의 CollaborationRecruitment가 생깁니다(초기인원용, 모집인원용). 초기 인원용이 gathering id가 null 로 설계되어 있어서 모집인원 구할 때 NPE 났던 걸 수정했습니다.

<!-- 수정/추가한 내용을 적어주세요. -->
