### PR TITLE
[FIX] 조회 시 이름이 아닌 닉네임을 반환하도록 변경 (#223)

### DIFF
--- a/src/main/java/com/brainpix/post/converter/GetCollaborationHubDetailDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetCollaborationHubDetailDtoConverter.java
@@ -73,7 +73,7 @@ public class GetCollaborationHubDetailDtoConverter {
 
 		return GetCollaborationHubDetailDto.Writer.builder()
 			.writerId(writer.getId())
-			.name(writer.getName())
+			.name(writer.getNickName())
 			.profileImageUrl(writer.getProfileImage())
 			.role(writer.getUserType())
 			.specialization(!writer.getProfile().getSpecializationList().isEmpty() ?
@@ -95,7 +95,7 @@ public class GetCollaborationHubDetailDtoConverter {
 	public static GetCollaborationHubDetailDto.OpenMember toOpenMember(CollectionGathering collectionGathering) {
 		return GetCollaborationHubDetailDto.OpenMember.builder()
 			.userId(collectionGathering.getJoiner().getId())
-			.name(collectionGathering.getJoiner().getName())
+			.name(collectionGathering.getJoiner().getNickName())
 			.domain(collectionGathering.getCollaborationRecruitment().getDomain())
 			.openMyProfile(collectionGathering.getOpenProfile())
 			.build();

--- a/src/main/java/com/brainpix/post/converter/GetCollaborationHubListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetCollaborationHubListDtoConverter.java
@@ -72,7 +72,7 @@ public class GetCollaborationHubListDtoConverter {
 			.collaborationId(collaborationHub.getId())
 			.auth(collaborationHub.getPostAuth().toString())
 			.writerImageUrl(collaborationHub.getWriter().getProfileImage())
-			.writerName(collaborationHub.getWriter().getName())
+			.writerName(collaborationHub.getWriter().getNickName())
 			.thumbnailImageUrl(
 				!collaborationHub.getImageList().isEmpty() ? collaborationHub.getImageList().get(0) : null)
 			.title(collaborationHub.getTitle())

--- a/src/main/java/com/brainpix/post/converter/GetCommentListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetCommentListDtoConverter.java
@@ -53,7 +53,7 @@ public class GetCommentListDtoConverter {
 			.commentId(comment.getId())
 			.writerId(comment.getWriter().getId())
 			.content(comment.getContent())
-			.writerName(comment.getWriter().getName())
+			.writerName(comment.getWriter().getNickName())
 			.parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
 			.childComments(new ArrayList<>())
 			.createdDate(comment.getCreatedAt().toLocalDate())

--- a/src/main/java/com/brainpix/post/converter/GetIdeaDetailDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetIdeaDetailDtoConverter.java
@@ -49,7 +49,7 @@ public class GetIdeaDetailDtoConverter {
 	public static GetIdeaDetailDto.Writer toWriter(User writer, Long totalIdeas, Long totalCollaborations) {
 		return GetIdeaDetailDto.Writer.builder()
 			.writerId(writer.getId())
-			.name(writer.getName())
+			.name(writer.getNickName())
 			.profileImageUrl(writer.getProfileImage())
 			.role(writer.getUserType())
 			.specialization(!writer.getProfile().getSpecializationList().isEmpty() ?

--- a/src/main/java/com/brainpix/post/converter/GetIdeaListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetIdeaListDtoConverter.java
@@ -55,7 +55,7 @@ public class GetIdeaListDtoConverter {
 			.ideaId(ideaMarket.getId())
 			.auth(ideaMarket.getPostAuth().toString())
 			.writerImageUrl(ideaMarket.getWriter().getProfileImage())
-			.writerName(ideaMarket.getWriter().getName())
+			.writerName(ideaMarket.getWriter().getNickName())
 			.thumbnailImageUrl(!ideaMarket.getImageList().isEmpty() ? ideaMarket.getImageList().get(0) : null)
 			.title(ideaMarket.getTitle())
 			.price(ideaMarket.getPrice().getPrice())

--- a/src/main/java/com/brainpix/post/converter/GetIdeaPurchasePageDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetIdeaPurchasePageDtoConverter.java
@@ -23,7 +23,7 @@ public class GetIdeaPurchasePageDtoConverter {
 			.title(ideaMarket.getTitle())
 			.remainingQuantity(ideaMarket.getPrice().getRemainingQuantity())
 			.sellerId(seller.getId())
-			.name(seller.getName())
+			.name(seller.getNickName())
 			.profileImageUrl(seller.getProfileImage())
 			.email(seller.getEmail())
 			.build();

--- a/src/main/java/com/brainpix/post/converter/GetPopularIdeaListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetPopularIdeaListDtoConverter.java
@@ -45,7 +45,7 @@ public class GetPopularIdeaListDtoConverter {
 			.ideaId(ideaMarket.getId())
 			.auth(ideaMarket.getPostAuth().toString())
 			.writerImageUrl(ideaMarket.getWriter().getProfileImage())
-			.writerName(ideaMarket.getWriter().getName())
+			.writerName(ideaMarket.getWriter().getNickName())
 			.thumbnailImageUrl(!ideaMarket.getImageList().isEmpty() ? ideaMarket.getImageList().get(0) : null)
 			.title(ideaMarket.getTitle())
 			.price(ideaMarket.getPrice().getPrice())

--- a/src/main/java/com/brainpix/post/converter/GetPopularRequestTaskListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetPopularRequestTaskListDtoConverter.java
@@ -42,7 +42,7 @@ public class GetPopularRequestTaskListDtoConverter {
 			.taskId(requestTask.getId())
 			.auth(requestTask.getPostAuth().toString())
 			.writerImageUrl(requestTask.getWriter().getProfileImage())
-			.writerName(requestTask.getWriter().getName())
+			.writerName(requestTask.getWriter().getNickName())
 			.thumbnailImageUrl(!requestTask.getImageList().isEmpty() ? requestTask.getImageList().get(0) : null)
 			.title(requestTask.getTitle())
 			.deadline(deadline)

--- a/src/main/java/com/brainpix/post/converter/GetRequestTaskDetailDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetRequestTaskDetailDtoConverter.java
@@ -58,7 +58,7 @@ public class GetRequestTaskDetailDtoConverter {
 	public static GetRequestTaskDetailDto.Writer toWriter(User writer, Long totalIdeas, Long totalCollaborations) {
 		return GetRequestTaskDetailDto.Writer.builder()
 			.writerId(writer.getId())
-			.name(writer.getName())
+			.name(writer.getNickName())
 			.profileImageUrl(writer.getProfileImage())
 			.role(writer.getUserType())
 			.specialization(!writer.getProfile().getSpecializationList().isEmpty() ?

--- a/src/main/java/com/brainpix/post/converter/GetRequestTaskListDtoConverter.java
+++ b/src/main/java/com/brainpix/post/converter/GetRequestTaskListDtoConverter.java
@@ -52,7 +52,7 @@ public class GetRequestTaskListDtoConverter {
 			.taskId(requestTask.getId())
 			.auth(requestTask.getPostAuth().toString())
 			.writerImageUrl(requestTask.getWriter().getProfileImage())
-			.writerName(requestTask.getWriter().getName())
+			.writerName(requestTask.getWriter().getNickName())
 			.thumbnailImageUrl(!requestTask.getImageList().isEmpty() ? requestTask.getImageList().get(0) : null)
 			.title(requestTask.getTitle())
 			.deadline(deadline)


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #223 

## ✨ PR 세부 내용

- 조회 관련 컨버터에서 이름이 아닌 닉네임을 반환하도록 통일하였습니다.