### PR TITLE
[FEAT] 협업 광장 내 개최 인원 유저 고유 아이디 반환 API 구현 (#233)

### DIFF
--- a/src/main/java/com/brainpix/post/controller/CollaborationHubCommandController.java
+++ b/src/main/java/com/brainpix/post/controller/CollaborationHubCommandController.java
@@ -61,10 +61,10 @@ public class CollaborationHubCommandController {
 		return ResponseEntity.ok(ApiResponse.successWithNoData());
 	}
 
-	@Operation(summary = "협업 광장 內 개최 인원 아이디 검증", description = "개최 인원 정보 파트에 아이디 입력 후 포트폴리오 불러오기를 통해 아이디의 존재 여부를 검증합니다.")
+	@Operation(summary = "협업 광장 內 개최 인원 유저 고유 아이디 반환", description = "개최 인원 정보 파트에 로그인 아이디 입력 후 포트폴리오 불러오기를 통해 유저 고유 아이디를 반환하여 유저 프로필에 접근할 수 있도록 합니다.")
 	@GetMapping("/validate/{identifier}")
-	public ResponseEntity<ApiResponse<Void>> validateUserIdentifier(@PathVariable String identifier) {
-		collaborationHubInitialMemberService.validateUserIdentifier(identifier);
-		return ResponseEntity.ok(ApiResponse.successWithNoData());
+	public ResponseEntity<ApiResponse<Long>> validateUserIdentifier(@PathVariable String identifier) {
+		Long userId = collaborationHubInitialMemberService.validateUserIdentifier(identifier);
+		return ResponseEntity.ok(ApiResponse.success(userId));
 	}
 }

--- a/src/main/java/com/brainpix/post/service/CollaborationHubInitialMemberService.java
+++ b/src/main/java/com/brainpix/post/service/CollaborationHubInitialMemberService.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.brainpix.api.code.error.CommonErrorCode;
 import com.brainpix.api.code.error.PostErrorCode;
 import com.brainpix.api.exception.BrainPixException;
 import com.brainpix.joining.service.InitialCollectionGatheringService;
@@ -53,12 +52,13 @@ public class CollaborationHubInitialMemberService {
 		}
 	}
 
-	//개최 인원 아이디 검증
-	public void validateUserIdentifier(String identifier) {
-		boolean exists = userRepository.existsByIdentifier(identifier);
+	//개최 인원 유저 고유 아이디 반환
+	public Long validateUserIdentifier(String identifier) {
+		User joiner = userRepository.findByIdentifier(identifier)
+			.orElseThrow(
+				() -> new BrainPixException(
+					PostErrorCode.USER_NOT_FOUND));
 
-		if (!exists) {
-			throw new BrainPixException(CommonErrorCode.RESOURCE_NOT_FOUND); // "해당 ID의 유저를 찾을 수 없습니다.");
-		}
+		return joiner.getId();
 	}
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[FEAT]: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #233

## ✨ PR 세부 내용
- 개최 인원 프로필에 접근하기 위해 로그인 아이디를 통해 유저 고유 아이디를 반환하는 API를 구현했습니다.
<!-- 수정/추가한 내용을 적어주세요. -->
