### PR TITLE
[FIX] 결제 시, 실제 배포 서버로 리다이렉트 되도록 url 변경 (#241)

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -40,7 +40,7 @@ kakao:
     cid: ENC(+Kb6JKxydvdU8AtNjy6i8E/0cr3mcK3/yIXO4oULT/Z41Ri57uepQtt7vEAl1uyk)
     ready-url: https://open-api.kakaopay.com/online/v1/payment/ready
     approve-url: https://open-api.kakaopay.com/online/v1/payment/approve
-    redirect-domain: http://localhost:5173
+    redirect-domain: https://www.brainpix.net
 
 cloud:
   aws:


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #241 

## ✨ PR 세부 내용

- 카카오페이 결제 관련 리다이렉트 도메인을 https://www.brainpix.net 로 변경하였습니다.
